### PR TITLE
Add ability to import valueMaps from templates

### DIFF
--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -6104,7 +6104,8 @@ class zabbixcli(cmd.Cmd):
                                                                 'templateLinkage': {'createMissing': True},
                                                                 'templates': {'createMissing': True, 'updateExisting': True},
                                                                 'templateScreens': {'createMissing': True, 'updateExisting': True},
-                                                                'triggers': {'createMissing': True, 'updateExisting': True}
+                                                                'triggers': {'createMissing': True, 'updateExisting': True},
+                                                                'valueMaps': {'createMissing': True, 'updateExisting': True},
                                                             })
 
                                 if data:


### PR DESCRIPTION
When we try import large template (with valueMaps) we get error: Cannot import valueMaps.
It fixed by appened import rule.