### PR TITLE
Merge with usit-gd:master

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,15 @@
-zabbix-cli (2.2.1-1) stable; urgency=low
+zabbix-cli (2.2.1) unstable; urgency=medium
 
+  [Andreas Dobloug]
   * New release 2.2.1
   * Updated the build system to use pybuild and require python3
 
-  -- Andreas Dobloug <andreas.dobloug@usit.uio.no>  Mon, 04 May 2020 16:42:00 +0200
+  [ Petter Reinholdtsen]
+  * Changed source format to native as it build from upstream git
+    repository.
+  * Added Andreas as package uploader.
+
+ -- Andreas Dobloug <andreas.dobloug@usit.uio.no>  Mon, 04 May 2020 16:42:00 +0200
 
 zabbix-cli (1.7.0-2) UNRELEASED; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,9 @@ Source: zabbix-cli
 Section: misc
 Priority: optional
 Maintainer: Rafael Martinez Guerrero <rafael@e-mc2.net>
-Uploaders: Petter Reinholdtsen <pere@debian.org>
+Uploaders:
+ Andreas Dobloug <andreas.dobloug@usit.uio.no>
+ , Petter Reinholdtsen <pere@debian.org>
 Build-Depends: debhelper (>= 10)
   , dh-python, python3-all
 Standards-Version: 4.0.0

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
* Changed Debian source format to native as it build from upstream git
* Added Andreas as Debian package uploader.
* releasing package zabbix-cli version 2.2.1 (fixed extra space in changelog and updated changelog)
