### PR TITLE
Use collections.abc.Mapping instead of collections.Mapping

### DIFF
--- a/zabbix_cli/config.py
+++ b/zabbix_cli/config.py
@@ -111,7 +111,7 @@ class OptionDescriptor(object):
                 '>').format(cls=type(self), obj=self)
 
 
-class OptionRegister(collections.Mapping):
+class OptionRegister(collections.abc.Mapping):
     """A registry of ConfigParser sections, options and default values."""
 
     def __init__(self):


### PR DESCRIPTION
`collections.Mapping` has been deprecated in Python 3.10 and must be replaced by `collections.abc.Mapping`.