### PR TITLE
Publish documentation to GitHub Pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,6 +26,9 @@ jobs:
         run: pip install Sphinx
       - name: Generate HTML documentation
         run: make -C docs singlehtml
+        env:
+          # Fail if there are warnings from Sphinx.
+          SPHINXOPTS: -W
       - name: Publish to GitHub pages
         uses: JamesIves/github-pages-deploy-action@v4.3.3
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    branches: [master]
+
+name: Documentation
+jobs:
+  build:
+    name: Build and publish documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: v1-pip-${{ runner.os }}-${{ hashFiles('setup.py') }}
+          restore-keys: |
+            v1-pip-${{ runner.os }}
+            v1-pip-
+      - name: Install Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.x
+      - name: Install Sphinx
+        run: pip install Sphinx
+      - name: Generate HTML documentation
+        run: make -C docs singlehtml
+      - name: Publish to GitHub pages
+        uses: JamesIves/github-pages-deploy-action@v4.3.3
+        with:
+          branch: gh-pages
+          folder: docs/_build/singlehtml

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,3 +18,6 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+manual: man
+	sed -i "$(BUILDDIR)/man/zabbix-cli.1" -e 's/do_\(.*\)()/\1/g'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ import os
 import sys
 
 # Add the parent directory on PYTHONPATH.
-sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 
 import os
 import sys
+import re
 
 # Add the parent directory on PYTHONPATH.
 sys.path.insert(0, os.path.abspath('..'))
@@ -77,6 +78,55 @@ def autodoc_skip_member_handler(app, what, name, obj, skip, options):
 def autodoc_process_signature_handler(app, what, name, obj, options, signature, return_annotation):
     return "", None
 
+def autodoc_process_docstring_handler(app, what, name, obj, options, lines):
+    """
+    Remove all DESCRIPTION.
+    Change all COMMAND: to be rendered as code blocks.
+    Sections don't work in docstrings, so change them to .. rubric::.
+    """
+    new_lines = []
+    for idx in range(len(lines)):
+        line = lines[idx]
+        desc = re.match("^DESCRIPTION:?(.+)?", line)
+        if desc:
+            if desc[1] is not None:
+                # Take 'foo' from 'DESCRIPTION: foo'.
+                new_lines.append(desc[1])
+            continue
+        command = re.match("^COMMAND:(.+)?$", line)
+        if command:
+            new_lines.append("::")
+            new_lines.append("")
+            # Handle 'COMMAND: foo [bar]'.
+            if command[1] is not None:
+                new_lines.append("  " + command[1])
+            # Modify the next items ahead of time.  We need to figure out
+            # how many arguments (if any), and indent each line.
+            lines_to_indent = 0
+            for i in range(idx + 1, len(lines)):
+                # Stop at the first empty line
+                next_line = lines[i]
+                if len(next_line) > 0:
+                    lines_to_indent += 1
+                else:
+                    break
+            for i in range(lines_to_indent):
+                lines[idx+1+i] = "  " + lines[idx+1+i]
+            continue
+        section = re.match("^-+$", line)
+        if section:
+            # For sections, remove the --- markers and instead add .. rubric::
+            # to the previous line.
+            old = new_lines[-1]
+            new = ".. rubric:: " + old
+            new_lines[-1] = new
+            continue
+        new_lines.append(line)
+
+    lines.clear()
+    lines += new_lines
+
 def setup(app):
+    app.connect('autodoc-process-docstring', autodoc_process_docstring_handler)
     app.connect('autodoc-process-signature', autodoc_process_signature_handler)
     app.connect('autodoc-skip-member', autodoc_skip_member_handler)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,11 +115,12 @@ def autodoc_process_docstring_handler(app, what, name, obj, options, lines):
             continue
         section = re.match("^-+$", line)
         if section:
-            # For sections, remove the --- markers and instead add .. rubric::
-            # to the previous line.
+            # For sections, remove the --- markers and instead add
+            # .. rubric:: to the previous line, plus a blank line.
             old = new_lines[-1]
             new = ".. rubric:: " + old
             new_lines[-1] = new
+            new_lines.append("")
             continue
         new_lines.append(line)
 

--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -772,17 +772,24 @@ class zabbixcli(cmd.Cmd):
 
         [Filter]:
         --------
-        * Zabbix agent: 'available': 0=Unknown
-                                     1=Available
-                                     2=Unavailable
+        * Zabbix agent: *available*:
 
-        * Maintenance: 'maintenance_status': 0:No maintenance
-                                             1:In progress
+          0. Unknown
+          1. Available
+          2. Unavailable
 
-        * Status: 'status': 0:Monitored
-                            1: Not monitored
+        * Maintenance: *maintenance_status*:
 
-        e.g.: Show all hosts with Zabbix agent: Available AND Status: Monitored:
+          0. No maintenance
+          1. In progress
+
+        * Status: *status*:
+
+          0. Monitored
+          1. Not monitored
+
+        e.g.: Show all hosts with ``Zabbix agent: Available AND Status: Monitored``::
+
               show_host * "'available':'1','status':'0'"
 
         """
@@ -1409,12 +1416,12 @@ class zabbixcli(cmd.Cmd):
 
         Priority values:
 
-        0 - (default) not classified;
-        1 - information;
-        2 - warning;
-        3 - average;
-        4 - high;
-        5 - disaster.
+        0. (default) not classified;
+        1. information;
+        2. warning;
+        3. average;
+        4. high;
+        5. disaster.
 
         [hostgroups]
         -----------
@@ -1429,15 +1436,15 @@ class zabbixcli(cmd.Cmd):
 
         Values:
 
-        true - (default) Show only active alarms with last event unacknowledged.
-        false - Show all active alarms, also those with the last event acknowledged.
+        * true - (default) Show only active alarms with last event unacknowledged.
+        * false - Show all active alarms, also those with the last event acknowledged.
 
 
-        e.g.: Get all alarms with priority 'High' that contain the word
-              'disk' in the description for the host 'host.example.org' and
-              the last event unacknowledged
+        e.g.: Get all alarms with priority ``High`` that contain the word
+        ``disk`` in the description for the host ``host.example.org`` and
+        the last event unacknowledged::
 
-        show_alarms *disk* "'host':'host.example.org','priority':'4'" * true
+          show_alarms *disk* "'host':'host.example.org','priority':'4'" * true
 
         """
         result_columns = {}
@@ -2281,14 +2288,14 @@ class zabbixcli(cmd.Cmd):
 
         [GUI access]
         ------------
-        0:'System default' [*]
-        1:'Internal'
-        2:'Disable'
+        0. 'System default' [*]
+        1. 'Internal'
+        2. 'Disable'
 
         [Status]
         --------
-        0:'Enable' [*]
-        1:'Disable'
+        0. 'Enable' [*]
+        1. 'Disable'
 
         """
         # Default 0: System default
@@ -2435,8 +2442,8 @@ class zabbixcli(cmd.Cmd):
 
         [Status]
         --------
-        0:'Monitored' [*]
-        1:'Unmonitored'
+        0. 'Monitored' [*]
+        1. 'Unmonitored'
 
         All host created with this command will get assigned a
         default interface of type 'Agent' using the port 10050.
@@ -2833,8 +2840,8 @@ class zabbixcli(cmd.Cmd):
 
         Type values:
 
-        0 - (default) With data collection
-        1 - Without data collection
+        0. (default) With data collection
+        1. Without data collection
 
         """
         host_ids = []
@@ -3030,15 +3037,15 @@ class zabbixcli(cmd.Cmd):
 
         [interface connection]
         ----------------------
-        0: Connect using host DNS name or interface DNS if provided [*]
-        1: Connect using host IP address
+        0. Connect using host DNS name or interface DNS if provided [*]
+        1. Connect using host IP address
 
         [interface type]
         ----------------
-        1: Zabbix agent
-        2: SNMP [*]
-        3: IPMI
-        4: JMX
+        1. Zabbix agent
+        2. SNMP [*]
+        3. IPMI
+        4. JMX
 
         [interface port]
         ----------------
@@ -3054,8 +3061,8 @@ class zabbixcli(cmd.Cmd):
 
         [default interface]
         -------------------
-        0: Not default interface
-        1: Default interface [*]
+        0. Not default interface
+        1. Default interface [*]
 
         """
         #
@@ -3235,14 +3242,14 @@ class zabbixcli(cmd.Cmd):
 
         [type]
         ------
-        1:'User' [*]
-        2:'Admin'
-        3:'Super admin'
+        1. 'User' [*]
+        2. 'Admin'
+        3. 'Super admin'
 
         [autologin]
         -----------
-        0:'Disable' [*]
-        1:'Enable'
+        0. 'Disable' [*]
+        1. 'Enable'
 
         [autologout]
         ------------
@@ -5226,8 +5233,8 @@ class zabbixcli(cmd.Cmd):
         -------
         Whether the output should group items with the same values.
 
-        0 - (default) Do not group items.
-        1 - Group items.
+        0. (default) Do not group items.
+        1. Group items.
         """
         try:
             arg_list = [arg.strip() for arg in shlex.split(args)]
@@ -6052,8 +6059,8 @@ class zabbixcli(cmd.Cmd):
         files that would be imported without running the import
         process.
 
-        0: Dry run deactivated
-        1: Dry run activated [*]
+        0. Dry run deactivated
+        1. Dry run activated [*]
 
         """
         #

--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -1939,8 +1939,8 @@ class zabbixcli(cmd.Cmd):
         one/several usergroups
 
         COMMAND:
-        remove_user_to_usergroup [username]
-                                 [usergroups]
+        remove_user_from_usergroup [username]
+                                   [usergroups]
 
 
         [username]
@@ -3443,6 +3443,7 @@ class zabbixcli(cmd.Cmd):
         create_notification_user [sendto]
                                  [mediatype]
                                  [remarks]
+
         [sendto]
         --------
         E-mail address, SMS number, jabber address, ...
@@ -3851,9 +3852,9 @@ class zabbixcli(cmd.Cmd):
         nothing will be changed.
 
         COMMAND:
-        define_usergroup_permissions [usergroup]
-                                     [hostgroups]
-                                     [permission code]
+        add_usergroup_permissions [usergroup]
+                                  [hostgroups]
+                                  [permission code]
 
         [usergroup]
         -----------
@@ -3945,7 +3946,7 @@ class zabbixcli(cmd.Cmd):
         on a hostgroup.
 
         COMMAND:
-        define_usergroup_permissions [usergroup]
+        update_usergroup_permissions [usergroup]
                                      [hostgroups]
                                      [permission code]
 
@@ -5222,6 +5223,7 @@ class zabbixcli(cmd.Cmd):
         Name of the items to get. Supports wildcard.
 
         [group]
+        -------
         Whether the output should group items with the same values.
 
         0 - (default) Do not group items.

--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -2428,7 +2428,7 @@ class zabbixcli(cmd.Cmd):
 
         * proxy-(prod|test)+d\\.example\\.org
           e.g. proxy-prod1.example.org and proxy-test8.example.org
-               will match this expression.
+          will match this expression.
 
         * .+
           All proxies will match this expression.
@@ -6041,7 +6041,7 @@ class zabbixcli(cmd.Cmd):
 
         This command finds all the pathnames matching a specified
         pattern according to the rules used by the Unix shell.  Tilde
-        expansion, *, ?, and character ranges expressed with [] will
+        expansion, \*, ?, and character ranges expressed with [] will
         be correctly matched. For a literal match, wrap the
         meta-characters in brackets. For example, '[?]' matches the
         character '?'.


### PR DESCRIPTION
This PR adds a CI job that publishes the latest documentation to https://unioslo.github.io/zabbix-cli/manual.html.

It also includes a small script that modifies our docstring format into reStructuredText directives that are rendered nicely by Sphinx, i.e. code blocks for `COMMAND` and proper `[arg]` section headings for...

```
[arg]
-----
Description of arg
```

(...somewhat ironically the latter is perfectly good RST, but Sphinx does not process sections in docstrings...)

You can see the result in action here: https://mbakke.github.io/zabbix-cli/manual.html