### PR TITLE
Fix: limit upper case conversion of host user macros to name part and leave context part as is

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ build/
 
 .venv/
 venv/
+
 .dccache
 .vscode/launch.json
+my_tests/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build/
 
 .venv/
 venv/
+.dccache
+.vscode/launch.json

--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -4572,7 +4572,10 @@ class zabbixcli(cmd.Cmd):
             return False
 
         else:
-            host_macro_name = '{$' + host_macro_name.upper() + '}'
+            # Change to upper case only the name part (before colon),
+            # as the context part (after colon) has to match exactly
+            parts = host_macro_name.partition(':') 
+            host_macro_name = '{$' + parts[0].upper() + parts[1] + parts[2] + '}'
 
         if host_macro_value == '':
             self.generate_feedback('Error', 'Host macro value is empty')


### PR DESCRIPTION

Fixes #132 

For example:
```
define_host_usermacro test-issue-132 'max_usage:/home/' 'some value'
define_host_usermacro test-issue-132 'macro_name:regex:[abc]+' 'some value'
```

Current behaviour:
```
+---------+----------------------------+------------+
| MacroID | Name                       | Value      |
+---------+----------------------------+------------+
|  123456 | {$MAX_USAGE:/HOME/}        | some value |
+---------+----------------------------+------------+
|  123457 | {$MACRO_NAME:REGEX:[ABC]+} | some value |
+---------+----------------------------+------------+
```

Fixed:
```
+---------+----------------------------+------------+
| MacroID | Name                       | Value      |
+---------+----------------------------+------------+
|  123456 | {$MAX_USAGE:/home/}        | some value |
+---------+----------------------------+------------+
|  123457 | {$MACRO_NAME:regex:[abc]+} | some value |
+---------+----------------------------+------------+
```

[define_host_usermacro_tests.txt](https://github.com/unioslo/zabbix-cli/files/9734267/define_host_usermacro_tests.txt)
