### PR TITLE
Fix Array index out of bound in some cases

### DIFF
--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -900,7 +900,10 @@ class zabbixcli(cmd.Cmd):
 
         for host in result:
             if self.zabbix_version >= 6:
-                available = host['interfaces'][0]['available']
+                if len(host['interfaces']) > 0:
+                    available = host['interfaces'][0]['available']
+                else:
+                    available = 0
             else:
                 available = host['available']
             proxy = self.zapi.proxy.get(proxyids=host['proxy_hostid'])

--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -903,7 +903,7 @@ class zabbixcli(cmd.Cmd):
                 if len(host['interfaces']) > 0:
                     available = host['interfaces'][0]['available']
                 else:
-                    available = 0
+                    available = "0"
             else:
                 available = host['available']
             proxy = self.zapi.proxy.get(proxyids=host['proxy_hostid'])


### PR DESCRIPTION
In somes cases, hosts does not have any interface
When this cases happen, we face an Array Index Out Of Bound. 

Maybe not the perfect fix but at least prevent cli from crashing.