### PR TITLE
Fix Ubuntu version & add new Python versions to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.6'
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
+          - '3.12'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ name: CI
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - '3.6'
+          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'


### PR DESCRIPTION
This PR ~~removes the EOL Python versions (3.6 & 3.7)~~<sup>*</sup> and adds the most recent versions (3.11 & 3.12) to/from the CI test matrix. The Ubuntu version is also changed from `latest` to `20.04` due to dropped 3.6 support in `latest` (22.04).

Once this PR is merged, the versions we officially support are the following:

- 3.6
- 3.7
- 3.8
- 3.9
- 3.10
- 3.11
- 3.12

----

\* I think it might be important to keep supporting Python 3.6 due to building RPM packages for RHEL 8. Need input on this. Also keeping around 2 extra versions in CI isn't that big of a deal, since the test suite takes very little time to execute.