### PR TITLE
Fix username login param for Zabbix>=6.4

### DIFF
--- a/tests/test_pyzabbix.py
+++ b/tests/test_pyzabbix.py
@@ -1,0 +1,28 @@
+from typing import Optional
+import pytest
+from packaging.version import Version
+
+from zabbix_cli.pyzabbix import user_param_from_version
+
+
+@pytest.mark.parametrize(
+        "version, expect",
+        [
+            (None, "username"), # default
+            (Version("7.0.0"), "username"),
+            (Version("6.0.0"), "username"),
+            (Version("6.2.0"), "username"),
+            (Version("6.4.0"), "username"),
+            (Version("5.4.0"), "username"),
+            (Version("5.4.1"), "username"),
+            (Version("5.3.9"), "user"),
+            (Version("5.2.0"), "user"),
+            (Version("5.2"), "user"),
+            (Version("5.0"), "user"),
+            (Version("4.0"), "user"),
+            (Version("2.0"), "user"),
+        ],
+)
+def test_user_param_from_version(version: Optional[Version], expect: str):
+    assert user_param_from_version(version) == expect
+

--- a/tests/test_pyzabbix.py
+++ b/tests/test_pyzabbix.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import pytest
 from packaging.version import Version
 
@@ -8,7 +7,6 @@ from zabbix_cli.pyzabbix import user_param_from_version
 @pytest.mark.parametrize(
         "version, expect",
         [
-            (None, "username"), # default
             (Version("7.0.0"), "username"),
             (Version("6.0.0"), "username"),
             (Version("6.2.0"), "username"),
@@ -23,6 +21,6 @@ from zabbix_cli.pyzabbix import user_param_from_version
             (Version("2.0"), "user"),
         ],
 )
-def test_user_param_from_version(version: Optional[Version], expect: str):
+def test_user_param_from_version(version: Version, expect: str):
     assert user_param_from_version(version) == expect
 

--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -82,8 +82,7 @@ class zabbixcli(cmd.Cmd):
             else:
                 self.zapi.session.verify = self.conf.cert_verify
             zabbix_auth_token_file = os.getenv('HOME') + '/.zabbix-cli_auth_token'
-            self.zabbix_version = Version(self.zapi.apiinfo.version())
-            self.api_auth_token = self.zapi.login(self.api_username, self.api_password, self.api_auth_token, self.zabbix_version)
+            self.api_auth_token = self.zapi.login(self.api_username, self.api_password, self.api_auth_token)
             self.zapi.user.get(userids=-1)  # Dummy call to verify authentication
         except Exception as e:
             print('\n[ERROR]: ' + str(e) + '\n')
@@ -106,6 +105,7 @@ class zabbixcli(cmd.Cmd):
             sys.exit(1)
 
         logger.debug('Connected to Zabbix JSON-API')
+        self.zabbix_version = self.zapi.version
 
         #
         # The file $HOME/.zabbix-cli_auth_token is created if it does not exists.

--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -82,7 +82,8 @@ class zabbixcli(cmd.Cmd):
             else:
                 self.zapi.session.verify = self.conf.cert_verify
             zabbix_auth_token_file = os.getenv('HOME') + '/.zabbix-cli_auth_token'
-            self.api_auth_token = self.zapi.login(self.api_username, self.api_password, self.api_auth_token)
+            self.zabbix_version = Version(self.zapi.apiinfo.version())
+            self.api_auth_token = self.zapi.login(self.api_username, self.api_password, self.api_auth_token, self.zabbix_version)
             self.zapi.user.get(userids=-1)  # Dummy call to verify authentication
         except Exception as e:
             print('\n[ERROR]: ' + str(e) + '\n')
@@ -105,8 +106,6 @@ class zabbixcli(cmd.Cmd):
             sys.exit(1)
 
         logger.debug('Connected to Zabbix JSON-API')
-
-        self.zabbix_version = Version(self.zapi.apiinfo.version())
 
         #
         # The file $HOME/.zabbix-cli_auth_token is created if it does not exists.

--- a/zabbix_cli/pyzabbix.py
+++ b/zabbix_cli/pyzabbix.py
@@ -81,7 +81,6 @@ class ZabbixAPI(object):
         # Attributes for properties
         self._version = None
 
-
     def login(self, user='', password='', auth_token=''):
         """
         Convenience method for calling user.authenticate and storing the

--- a/zabbix_cli/pyzabbix.py
+++ b/zabbix_cli/pyzabbix.py
@@ -124,7 +124,7 @@ class ZabbixAPI(object):
             params={"format": format, "source": source, "rules": rules}
         )['result']
 
-
+    # TODO (pederhan): Use functools.cachedproperty when we drop 3.7 support
     @property
     def version(self) -> Version:
         """Alternate version of api_version() that caches version info


### PR DESCRIPTION
The application now chooses the correct `user.login` parameter based on the Zabbix version it is running against (`username` on >=5.4, otherwise `user`).

The application now fetches the Zabbix API version _before_ login instead of after to facilitate this new behavior. 

A new property `zabbix_cli.pyzabbix.ZabbixAPI.version` has been added, which returns the Zabbix API version as a `packaging.version.Version`. This is a cached property, which we re-use in `zabbix_cli.cli.zabbixcli` to set the `zabbix_version` attribute.

Fixes #160. 