### PR TITLE
Fix host group type error on >= 6.2

### DIFF
--- a/zabbix_cli/cli.py
+++ b/zabbix_cli/cli.py
@@ -635,7 +635,7 @@ class zabbixcli(cmd.Cmd):
                 result_columns[result_columns_key] = {'groupid': group['groupid'],
                                                       'name': group['name'],
                                                       'flags': zabbix_cli.utils.get_hostgroup_flag(int(group['flags'])),
-                                                      'type': zabbix_cli.utils.get_hostgroup_type(int(group['internal'])),
+                                                      'type': zabbix_cli.utils.get_hostgroup_type(int(group.get('internal', 0))),
                                                       'hosts': group['hosts']}
             else:
                 host_list = []
@@ -647,7 +647,7 @@ class zabbixcli(cmd.Cmd):
                 result_columns[result_columns_key] = {'1': group['groupid'],
                                                       '2': group['name'],
                                                       '3': zabbix_cli.utils.get_hostgroup_flag(int(group['flags'])),
-                                                      '4': zabbix_cli.utils.get_hostgroup_type(int(group['internal'])),
+                                                      '4': zabbix_cli.utils.get_hostgroup_type(int(group.get('internal', 0))),
                                                       '5': '\n'.join(textwrap.wrap(', '.join(host_list), 60))}
             result_columns_key = result_columns_key + 1
 


### PR DESCRIPTION
Fixes #170 

NOTE: This is more or less a band-aid fix for now. On Zabbix >= 6.2, all groups are displayed as `Not internal (0)`, since the concept of "internal" host groups is gone. Ideally, this column should be hidden on the relevant versions of Zabbix, but that requires some non-trivial changes to the output rendering, which is something I want to revise with a more holistic approach in a future PR.

Zabbix 7.0: 


```
#############################################################
Welcome to the Zabbix command-line interface (v2.3.1)
Connected to server http://localhost:8082 (v7.0.0)
#############################################################
Type help or \? to list commands.

[zabbix-cli Admin@Admin]$ show_hostgroup Applications
+---------+--------------+-----------+------------------+----------------------+
| GroupID | Name         |    Flag   |       Type       | Hosts                |
+---------+--------------+-----------+------------------+----------------------+
|      19 | Applications | Plain (0) | Not internal (0) | db.no, nrk.no, vg.no |
+---------+--------------+-----------+------------------+----------------------+

[zabbix-cli Admin@Admin]$ show_hostgroups
+---------+------------------+-----------+------------------+----------------------+
| GroupID | Name             |    Flag   |       Type       | Hosts                |
+---------+------------------+-----------+------------------+----------------------+
|      19 | Applications     | Plain (0) | Not internal (0) | db.no, nrk.no, vg.no |
+---------+------------------+-----------+------------------+----------------------+
|      20 | Databases        | Plain (0) | Not internal (0) |                      |
+---------+------------------+-----------+------------------+----------------------+
|       5 | Discovered hosts | Plain (0) | Not internal (0) |                      |
+---------+------------------+-----------+------------------+----------------------+
|       7 | Hypervisors      | Plain (0) | Not internal (0) |                      |
+---------+------------------+-----------+------------------+----------------------+
|       2 | Linux servers    | Plain (0) | Not internal (0) |                      |
+---------+------------------+-----------+------------------+----------------------+
|       6 | Virtual machines | Plain (0) | Not internal (0) |                      |
+---------+------------------+-----------+------------------+----------------------+
|       4 | Zabbix servers   | Plain (0) | Not internal (0) | Zabbix server        |
+---------+------------------+-----------+------------------+----------------------+
```