### PR TITLE
Command help tense

### DIFF
--- a/zabbix_cli/commands/cli.py
+++ b/zabbix_cli/commands/cli.py
@@ -112,7 +112,7 @@ def open_config_dir(
         help="Specify command to use to use for opening.",
     ),
 ) -> None:
-    """Opens an app directory in the system's file manager.
+    """Open an app directory in the system's file manager.
 
     Use --force to attempt to open when no DISPLAY env var is set.
     """
@@ -265,7 +265,7 @@ def migrate_config(
         conf = app.state.config
         if not conf.app.is_legacy:
             p = f"'{conf.config_path}' " if conf.config_path else ""
-            exit_err(f"Loaded config {p}is not a legacy .conf config file file.")
+            exit_err(f"Loaded config {p}is not a legacy .conf config file.")
 
     if not destination:
         destination = DEFAULT_CONFIG_FILE

--- a/zabbix_cli/commands/hostgroup.py
+++ b/zabbix_cli/commands/hostgroup.py
@@ -40,9 +40,9 @@ def add_host_to_hostgroup(
         help="Preview changes",
     ),
 ) -> None:
-    """Adds one or more hosts to one or more host groups.
+    """Add hosts to host groups.
 
-    Host{name,group} arguments are interpreted as IDs if they are numeric.
+    Host name and group arguments are interpreted as IDs if they are numeric.
     """
     from zabbix_cli.commands.results.hostgroup import AddHostsToHostGroup
     from zabbix_cli.models import AggregateResult
@@ -92,7 +92,7 @@ def remove_host_from_hostgroup(
         help="Preview changes",
     ),
 ) -> None:
-    """Remove one or more hosts from one or more host groups."""
+    """Remove hosts from host groups."""
     from zabbix_cli.commands.results.hostgroup import RemoveHostsFromHostGroup
     from zabbix_cli.models import AggregateResult
 
@@ -254,7 +254,7 @@ def extend_hostgroup(
         help="Show hosts and groups without making changes.",
     ),
 ) -> None:
-    """Add all hosts from a host group to other host group(s).
+    """Add all hosts from a host group to other host groups.
 
     The source group is not modified. Existing hosts in the destination group(s)
     are not removed or modified.
@@ -397,7 +397,7 @@ def show_hostgroup_permissions(
         None, help="Host group name(s). Comma-separated. Supports wildcards."
     ),
 ) -> None:
-    """Show usergroups with permissions for the given hostgroup. Supports wildcards.
+    """Show usergroups with permissions for the given hostgroup.
 
     Shows permissions for all host groups by default.
     """

--- a/zabbix_cli/commands/item.py
+++ b/zabbix_cli/commands/item.py
@@ -42,7 +42,7 @@ def show_last_values(
     ),
     args: Optional[List[str]] = ARGS_POSITIONAL,
 ) -> None:
-    """Shows the last values of given item(s) of monitored hosts."""
+    """Show the last values of given items of monitored hosts."""
     from zabbix_cli.commands.results.item import ItemResult
     from zabbix_cli.commands.results.item import group_items
     from zabbix_cli.models import AggregateResult

--- a/zabbix_cli/commands/macro.py
+++ b/zabbix_cli/commands/macro.py
@@ -85,7 +85,7 @@ def define_host_usermacro(
 def show_host_usermacros(
     hostname_or_id: str = typer.Argument(help="Hostname or ID to show macros for"),
 ) -> None:
-    """Shows all macros defined for a host."""
+    """Show all macros defined for a host."""
     from zabbix_cli.commands.results.macro import ShowHostUserMacrosResult
     from zabbix_cli.models import AggregateResult
 

--- a/zabbix_cli/commands/problem.py
+++ b/zabbix_cli/commands/problem.py
@@ -38,7 +38,7 @@ def acknowledge_event(
     # Legacy positional args
     args: Optional[List[str]] = ARGS_POSITIONAL,
 ) -> None:
-    """Acknowledge event(s) by ID."""
+    """Acknowledge events by ID."""
     from zabbix_cli.commands.results.problem import AcknowledgeEventResult
     from zabbix_cli.models import Result
 
@@ -104,7 +104,7 @@ def acknowledge_trigger_last_event(
     # Legacy positional args
     args: Optional[List[str]] = ARGS_POSITIONAL,
 ) -> None:
-    """Acknowledges the the last event for the given trigger(s)."""
+    """Acknowledge the the last event for the given triggers."""
     from zabbix_cli.commands.results.problem import AcknowledgeTriggerLastEventResult
     from zabbix_cli.models import Result
 
@@ -186,7 +186,7 @@ def show_trigger_events(
     ),
     args: Optional[List[str]] = ARGS_POSITIONAL,
 ) -> None:
-    """Show the latest events for the given trigger(s), host(s), and/or host group(s).
+    """Show the latest events for the given triggers, hosts, and/or host groups.
 
     At least one trigger ID, host or host group must be specified.
     """
@@ -247,7 +247,7 @@ def show_alarms(
     ),
     args: Optional[List[str]] = ARGS_POSITIONAL,
 ) -> None:
-    """Show the latest events for the given trigger(s), host(s), and/or host group(s).
+    """Show the latest events for the given triggers, hosts, and/or host groups.
 
     At least one trigger ID, host or host group must be specified.
     """

--- a/zabbix_cli/commands/proxy.py
+++ b/zabbix_cli/commands/proxy.py
@@ -88,8 +88,9 @@ def update_host_proxy(
     proxy: str = typer.Argument(help="Proxy name. Supports wildcards."),
     dryrun: bool = typer.Option(False, help="Preview changes", is_flag=True),
 ) -> None:
-    """Assign one or more hosts to a proxy. Supports wildcards for both hosts and proxy.
+    """Assign hosts to a proxy.
 
+    Supports wildcards for both hosts and proxy names.
     If multiple proxies match the proxy name, the first match is used.
     """
     from zabbix_cli.commands.results.proxy import UpdateHostProxyResult
@@ -291,7 +292,7 @@ def load_balance_proxy_hosts(
         show_default=False,
     ),
 ) -> None:
-    """Spreads hosts between multiple proxies.
+    """Spread hosts between multiple proxies.
 
     Hosts are determined by the hosts monitored by the given proxies
     Hosts monitored by other proxies or not monitored at all are not affected.

--- a/zabbix_cli/commands/template.py
+++ b/zabbix_cli/commands/template.py
@@ -155,7 +155,7 @@ def link_template_to_host(
         help="Preview changes.",
     ),
 ) -> None:
-    """Link template(s) to host(s)."""
+    """Link templates to hosts."""
     from zabbix_cli.commands.results.template import LinkTemplateToHostResult
     from zabbix_cli.models import AggregateResult
 
@@ -227,7 +227,7 @@ def unlink_template_from_host(
         True, "--clear/--no-clear", help="Unlink and clear templates."
     ),
 ) -> None:
-    """Unlinks templates from hosts.
+    """Unlink templates from hosts.
 
     Unlinks and clears by default. Use `--no-clear` to unlink without clearing.
     """
@@ -299,7 +299,7 @@ def link_template_to_template(
         help="Do not actually link templates, just show what would be done.",
     ),
 ) -> None:
-    """Link template(s) to templates(s).
+    """Link templates to templates.
 
     [b]NOTE:[/] Destination templates are the ones that are ultimately modified. Source templates remain unchanged.
     """
@@ -369,7 +369,7 @@ def unlink_template_from_template(
         help="Preview changes.",
     ),
 ) -> None:
-    """Unlink template(s) from templates(s).
+    """Unlink templates from templates.
 
     Unlinks and clears by default. Use `--no-clear` to unlink without clearing.
     [b]NOTE:[/] Destination templates are the ones that are ultimately modified. Source templates remain unchanged.
@@ -419,7 +419,7 @@ def add_template_to_group(
         help="Fail if any host groups or templates aren't found. Should not be used in conjunction with wildcards.",
     ),
 ) -> None:
-    """Add template(s) to group(s).
+    """Add templates to groups.
 
     [bold]NOTE:[/] Group arguments are interpreted as template groups in >= 6.2,
     otherwise as host groups.

--- a/zabbix_cli/commands/templategroup.py
+++ b/zabbix_cli/commands/templategroup.py
@@ -67,7 +67,7 @@ def create_templategroup(
 
     Use --no-usergroup-permissions to create a group without assigning user group permissions.
 
-    NOTE: Calls [green]create_hostgroup[/] for Zabbix versions < 6.2.0.
+    NOTE: Calls [command]create_hostgroup[/] for Zabbix versions < 6.2.0.
     """
     from zabbix_cli.models import Result
 
@@ -130,7 +130,7 @@ def remove_templategroup(
 ) -> None:
     """Delete a template group.
 
-    NOTE: Calls [green]remove_hostgroup[/] for Zabbix <6.2.
+    NOTE: Calls [command]remove_hostgroup[/] for Zabbix <6.2.
     """
     from zabbix_cli.models import Result
 
@@ -238,7 +238,7 @@ def show_templategroups(
 
 
 @app.command("extend_templategroup", rich_help_panel=HELP_PANEL)
-def show_triggers(
+def extend_templategroup(
     ctx: typer.Context,
     src_group: str = typer.Argument(help="Group to get templates from."),
     dest_group: str = typer.Argument(
@@ -255,7 +255,7 @@ def show_triggers(
     Interprets the source group as a template group in >= 6.2, otherwise as a host group.
 
     Does not modify the source group or its templates.
-    To remove the templates from the source group, use the [green]move_templates[/] command instead.
+    To remove the templates from the source group, use the [command]move_templates[/] command instead.
     """
     from zabbix_cli.commands.results.templategroup import ExtendTemplateGroupResult
 

--- a/zabbix_cli/commands/templategroup.py
+++ b/zabbix_cli/commands/templategroup.py
@@ -130,7 +130,7 @@ def remove_templategroup(
 ) -> None:
     """Delete a template group.
 
-    NOTE: Calls [green]delete_hostgroup[/] for Zabbix versions < 6.2.0.
+    NOTE: Calls [green]remove_hostgroup[/] for Zabbix <6.2.
     """
     from zabbix_cli.models import Result
 
@@ -156,7 +156,7 @@ def show_templategroup(
         help="Show/hide templates associated with the group.",
     ),
 ) -> None:
-    """Show details for a template groups."""
+    """Show details for a template group."""
     from zabbix_cli.commands.results.templategroup import ShowTemplateGroupResult
 
     tg: HostGroup | TemplateGroup
@@ -200,7 +200,7 @@ def show_templategroups(
         help="Show/hide templates associated with each group.",
     ),
 ) -> None:
-    """Show details for template groups.
+    """Show template groups.
 
     Fetches all groups by default, but can be filtered by name.
     """
@@ -250,7 +250,7 @@ def show_triggers(
         help="Show groups and templates without copying.",
     ),
 ) -> None:
-    """Add all templates from a group to other group(s).
+    """Add all templates from a group to other groups.
 
     Interprets the source group as a template group in >= 6.2, otherwise as a host group.
 

--- a/zabbix_cli/commands/user.py
+++ b/zabbix_cli/commands/user.py
@@ -439,7 +439,7 @@ def add_user_to_usergroup(
         help="User groups to add the users to. Comma-separated.",
     ),
 ) -> None:
-    """Adds user(s) to usergroup(s).
+    """Add users to usergroups.
 
     Ignores users not in user groups. Users and groups must exist.
     """
@@ -474,7 +474,7 @@ def remove_user_from_usergroup(
         help="User groups to remove the users from. Comma-separated.",
     ),
 ) -> None:
-    """Removes user(s) from usergroup(s).
+    """Remove users from usergroups.
 
     Ignores users not in user groups. Users and groups must exist.
     """
@@ -708,7 +708,7 @@ def add_usergroup_permissions(
     # Legacy V2 args
     args: Optional[List[str]] = ARGS_POSITIONAL,
 ) -> None:
-    """Gives a user group permissions to host groups and template groups.
+    """Give a user group permissions to host/template groups.
 
     Run [green]show_hostgroups[/] to get a list of host groups, and
     [green]show_templategroups --no-templates[/] to get a list of template groups.

--- a/zabbix_cli/commands/user.py
+++ b/zabbix_cli/commands/user.py
@@ -355,7 +355,7 @@ def create_notification_user(
     owns, but that can be used by other users to send notifications to the
     media defined in the notification user profile.
 
-    Run [green]show_media_types[/green] to get a list of available media types.
+    Run [command]show_media_types[/command] to get a list of available media types.
 
     Falls back on the user group defined in the config file if no user groups are specified.
     """
@@ -391,7 +391,7 @@ def create_notification_user(
         mt = app.state.client.get_mediatype(mediatype)
     except ZabbixNotFoundError:
         exit_err(
-            f"Media type {mediatype!r} does not exist. Run [green]show_media_types[/green] command to get a list of available media types."
+            f"Media type {mediatype!r} does not exist. Run [command]show_media_types[/command] command to get a list of available media types."
         )
 
     with app.status("Fetching usergroup(s)..."):
@@ -710,8 +710,8 @@ def add_usergroup_permissions(
 ) -> None:
     """Give a user group permissions to host/template groups.
 
-    Run [green]show_hostgroups[/] to get a list of host groups, and
-    [green]show_templategroups --no-templates[/] to get a list of template groups.
+    Run [command]show_hostgroups[/] to get a list of host groups, and
+    [command]show_templategroups --no-templates[/] to get a list of template groups.
     """
     from zabbix_cli.commands.results.user import AddUsergroupPermissionsResult
 

--- a/zabbix_cli/commands/user.py
+++ b/zabbix_cli/commands/user.py
@@ -348,16 +348,17 @@ def create_notification_user(
     event happens.
 
     Sometimes we need to send a notification to a place not owned by any
-    user in particular, e.g. an email list or jabber channel but Zabbix has
-    not the possibility of defining media for a usergroup.
+    user in particular, e.g. an email list or jabber channel but Zabbix does
+    not provide a way to define a media for a user group.
 
-    This is the reason we use [b]notification users[/]. They are users nobody
+    This is the reason we use [i]notification users[/]. They are users nobody
     owns, but that can be used by other users to send notifications to the
     media defined in the notification user profile.
 
     Run [command]show_media_types[/command] to get a list of available media types.
 
-    Falls back on the user group defined in the config file if no user groups are specified.
+    Uses the default notification user group defined in the configuration file
+    if no user groups are specified with [option]--usergroups[/option].
     """
     from zabbix_cli.models import Result
     from zabbix_cli.pyzabbix.types import User


### PR DESCRIPTION
Also use plural by default instead of (s) to denote optional plurality, as well as using `[command]` styling when referring to other commands in descriptions.