### PR TITLE
Add AUTHORS file, update pyproject.toml

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,32 @@
+# Based on `git shortlog --all -es` with duplicates removed
+
+Alexandru Tică
+Andreas Dobloug
+Boris Manojlovic
+Carl Morten Boger
+Emanuele Borin
+Fabian Arrotin
+Fabian Stelzer
+Florian Tham
+Fredrik Larsen
+Ganesh Hegde
+Herdir
+Jarle Bjørgeengen
+Jean-Baptiste Denis
+Jelmer Vernooĳ
+Kim Rioux-Paradis
+Logan V
+Marius Bakke
+Mathieu Marleix
+Michael Gindonis
+Mustafa Ocak
+Mélissa Bertin
+Paal Braathen
+Peder Hovdan Andresen
+Peet Whittaker
+Petter Reinholdtsen
+Rafael Martinez Guerrero
+Retyunskikh Dmitriy
+Steve McDuff
+Terje Kvernes
+Volker Fröhlich

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,14 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = "GPL-3.0-or-later"
 keywords = []
-authors = [
-  { name = "Rafael Martinez Guerrero", email = "rafael@postgresql.org.es" },
-]
 maintainers = [{ name = "Peder Hovdan Andresen", email = "pederhan@uio.no" }]
+authors = [
+  # Historical authors (pre-V3)
+  { name = "Rafael Martinez Guerrero", email = "rafael@postgresql.org.es" },
+  { name = "Paal Braathen", email = "paal.braathen@usit.uio.no" },
+  { name = "Marius Bakke", email = "marius.bakke@usit.uio.no" },
+  { name = "Others (see AUTHORS)" },
+]
 
 classifiers = [
   "Environment :: Console",


### PR DESCRIPTION
This PR adds a new `AUTHORS` file containing all historical authors on the project. It is not feasible to add all these names to pyproject.toml, so we keep them in a separate file. The top 3 historical authors have been added to `authors` in pyproject.toml.