### PR TITLE
Ensure valid markdown before rendering

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Status messages when fetching data from the Zabbix API in most `show_*` commands.
 - `--limit` option for most `show_*` commands to limit the number of results shown.
 
+### Fixed
+
+- Markup errors when rendering Zabbix items with keys containing special characters.
+
 ## 3.0.1
 
 ### Changed

--- a/zabbix_cli/models.py
+++ b/zabbix_cli/models.py
@@ -26,6 +26,7 @@ from strenum import StrEnum
 from typing_extensions import TypeVar
 
 from zabbix_cli.table import get_table
+from zabbix_cli.utils.rich import get_safe_renderable
 
 if TYPE_CHECKING:
     from rich.console import RenderableType
@@ -232,6 +233,10 @@ class TableRenderable(BaseModel):
     def as_table(self) -> Table:
         """Renders a Rich table given the rows and cols generated for the object."""
         cols, rows = self.__cols_rows__()
+        for row in rows:
+            for i, cell in enumerate(row):
+                row[i] = get_safe_renderable(cell)
+
         return get_table(
             cols=cols,
             rows=rows,

--- a/zabbix_cli/utils/rich.py
+++ b/zabbix_cli/utils/rich.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from rich.errors import MarkupError
+from rich.text import Text
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from rich.console import RenderableType
+
+
+def get_safe_renderable(renderable: RenderableType) -> RenderableType:
+    """Ensure that the renderable can be rendered without raising an exception."""
+    if isinstance(renderable, str):
+        return get_text(renderable)
+    return renderable
+
+
+def get_text(text: str) -> Text:
+    """Interpret text as markup-styled text, or plain text if it fails."""
+    try:
+        return Text.from_markup(text)
+    except MarkupError as e:
+        # Log this so that we can more easily debug incorrect rendering
+        # In most cases, this will be due to some Zabbix item key that looks
+        # like a markup tag, e.g. `system.cpu.load[percpu,avg]`
+        # but we need to log it nonetheless for other cases
+        logger.debug("Markup error when rendering text: '%s': %s", text, e)
+        return Text(text)


### PR DESCRIPTION
This PR fixes #199 by instantiating `rich.text.Text` objects of all strings in tables. We first try to call `Text.from_markup()`, but if that fails we instantiate a `Text` object directly with the given string, thus bypassing any markup parsing.