### PR TITLE
Specify tests directory in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
         run: |
           uv pip install --system .[test]
       - name: Test
-        run: python -m pytest -vv
+        run: python -m pytest -vv tests


### PR DESCRIPTION
The cached uv GitHub action seems to unpack its cached dependencies into the source code directory, which then makes invoking `pytest -vv` without an argument run tests on all source distributions that have tests. Since those source code distributions can have tests written for extras we don't have, those tests then fail.