### PR TITLE
Hide defaults for required arguments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,13 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `show_usermacro_host_list --limit` option to limit the number of results shown.
-- `show_usermacro_template_list --limit` option to limit the number of results shown.
+- `--limit` option for `show_*` commands to limit the number of results shown:
+  - `show_usermacro_host_list`
+  - `show_usermacro_template_list`
+  - `show_maintenance_periods`
 
 ### Changed
 
 - `show_host_usermacros` rendering of `automatic` field.
   - Now shows a human readable string instead of `0` or `1`.
+- Example formatting.
+- Hide defaults for required positional arguments.
 
 ### Fixed
 

--- a/zabbix_cli/commands/host.py
+++ b/zabbix_cli/commands/host.py
@@ -33,6 +33,7 @@ def create_host(
     ctx: typer.Context,
     hostname_or_ip: str = typer.Argument(
         help="Hostname or IP",
+        show_default=False,
     ),
     hostgroups: Optional[str] = typer.Option(
         None,
@@ -614,7 +615,10 @@ def monitor_host(
 @app.command(name="remove_host", rich_help_panel=HELP_PANEL)
 def remove_host(
     ctx: typer.Context,
-    hostname: str = typer.Argument(help="Name of host to remove."),
+    hostname: str = typer.Argument(
+        help="Name of host to remove.",
+        show_default=False,
+    ),
 ) -> None:
     """Delete a host."""
     from zabbix_cli.models import Result
@@ -627,7 +631,10 @@ def remove_host(
 @app.command(name="show_host", rich_help_panel=HELP_PANEL)
 def show_host(
     ctx: typer.Context,
-    hostname_or_id: str = typer.Argument(help="Hostname or ID."),
+    hostname_or_id: str = typer.Argument(
+        help="Hostname or ID.",
+        show_default=False,
+    ),
     active: Optional[ActiveInterface] = typer.Option(
         None,
         "--active",
@@ -784,7 +791,10 @@ def show_hosts(
 
 @app.command(name="show_host_interfaces", rich_help_panel=HELP_PANEL)
 def show_host_interfaces(
-    hostname_or_id: str = typer.Argument(help="Hostname or ID"),
+    hostname_or_id: str = typer.Argument(
+        help="Hostname or ID",
+        show_default=False,
+    ),
 ) -> None:
     """Show host interfaces."""
     from zabbix_cli.models import AggregateResult
@@ -795,7 +805,10 @@ def show_host_interfaces(
 
 @app.command(name="show_host_inventory", rich_help_panel=HELP_PANEL)
 def show_host_inventory(
-    hostname_or_id: str = typer.Argument(help="Hostname or ID"),
+    hostname_or_id: str = typer.Argument(
+        help="Hostname or ID",
+        show_default=False,
+    ),
 ) -> None:
     """Show host inventory details for a specific host."""
     # TODO: support undocumented filter argument from V2
@@ -807,9 +820,18 @@ def show_host_inventory(
 @app.command(name="update_host_inventory", rich_help_panel=HELP_PANEL)
 def update_host_inventory(
     ctx: typer.Context,
-    hostname_or_id: str = typer.Argument(help="Hostname or ID of host."),
-    key: str = typer.Argument(help="Inventory key"),
-    value: str = typer.Argument(help="Inventory value"),
+    hostname_or_id: str = typer.Argument(
+        help="Hostname or ID of host.",
+        show_default=False,
+    ),
+    key: str = typer.Argument(
+        help="Inventory key",
+        show_default=False,
+    ),
+    value: str = typer.Argument(
+        help="Inventory value",
+        show_default=False,
+    ),
 ) -> None:
     """Update a host inventory field.
 

--- a/zabbix_cli/commands/hostgroup.py
+++ b/zabbix_cli/commands/hostgroup.py
@@ -21,18 +21,35 @@ from zabbix_cli.utils.args import parse_hostnames_arg
 from zabbix_cli.utils.args import parse_list_arg
 
 
-@app.command("add_host_to_hostgroup", rich_help_panel=HELP_PANEL)
+@app.command(
+    "add_host_to_hostgroup",
+    rich_help_panel=HELP_PANEL,
+    examples=[
+        Example(
+            "Add a host to a host group",
+            "add_host_to_hostgroup 'My host' 'My host group'",
+        ),
+        Example(
+            "Add multiple hosts to a host group",
+            "add_host_to_hostgroup 'host1,host2' 'My host group'",
+        ),
+        Example(
+            "Add multiple hosts to multiple host groups",
+            "add_host_to_hostgroup 'host1,host2' 'My host group,Another group'",
+        ),
+    ],
+)
 def add_host_to_hostgroup(
     ctx: typer.Context,
-    hostnames_or_ids: Optional[str] = typer.Argument(
-        None,
+    hostnames_or_ids: str = typer.Argument(
         help="Host names or IDs. Comma-separated. Supports wildcards.",
         metavar="HOSTS",
+        show_default=False,
     ),
-    hostgroups: Optional[str] = typer.Argument(
-        None,
+    hostgroups: str = typer.Argument(
         help="Host group names or IDs. Comma-separated. Supports wildcards.",
         metavar="HOSTGROUPS",
+        show_default=False,
     ),
     dryrun: bool = typer.Option(
         False,
@@ -76,17 +93,34 @@ def add_host_to_hostgroup(
         success(f"Added {base_msg}.")
 
 
-@app.command("remove_host_from_hostgroup", rich_help_panel=HELP_PANEL)
+@app.command(
+    "remove_host_from_hostgroup",
+    rich_help_panel=HELP_PANEL,
+    examples=[
+        Example(
+            "Remove a host to a host group",
+            "remove_host_from_hostgroup 'My host' 'My host group'",
+        ),
+        Example(
+            "Remove multiple hosts from a host group",
+            "remove_host_from_hostgroup 'host1,host2' 'My host group'",
+        ),
+        Example(
+            "Remove multiple hosts from multiple host groups",
+            "remove_host_from_hostgroup 'host1,host2' 'My host group,Another group'",
+        ),
+    ],
+)
 def remove_host_from_hostgroup(
-    hostnames_or_ids: Optional[str] = typer.Argument(
-        None,
+    hostnames_or_ids: str = typer.Argument(
         help="Host names or IDs. Comma-separated. Supports wildcards.",
         metavar="HOSTS",
+        show_default=False,
     ),
-    hostgroups: Optional[str] = typer.Argument(
-        None,
+    hostgroups: str = typer.Argument(
         help="Host group names or IDs. Comma-separated. Supports wildcards.",
         metavar="HOSTGROUPS",
+        show_default=False,
     ),
     dryrun: bool = typer.Option(
         False,
@@ -143,7 +177,10 @@ def remove_host_from_hostgroup(
     ],
 )
 def create_hostgroup(
-    hostgroup: str = typer.Argument(help="Name of host group."),
+    hostgroup: str = typer.Argument(
+        help="Name of host group.",
+        show_default=False,
+    ),
     rw_groups: Optional[str] = typer.Option(
         None,
         "--rw-groups",
@@ -211,7 +248,8 @@ def create_hostgroup(
 @app.command("remove_hostgroup", rich_help_panel=HELP_PANEL)
 def delete_hostgroup(
     hostgroup: str = typer.Argument(
-        help="Name of host group(s) to delete. Comma-separated."
+        help="Name of host group(s) to delete. Comma-separated.",
+        show_default=False,
     ),
     force: bool = typer.Option(
         False,
@@ -248,9 +286,11 @@ def delete_hostgroup(
 def extend_hostgroup(
     src_group: str = typer.Argument(
         help="Group to get hosts from.",
+        show_default=False,
     ),
     dest_group: str = typer.Argument(
         help="Group(s) to add hosts to. Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
     dryrun: bool = typer.Option(
         False,
@@ -289,9 +329,11 @@ def extend_hostgroup(
 def move_hosts(
     src_group: str = typer.Argument(
         help="Group to move hosts from.",
+        show_default=False,
     ),
     dest_group: str = typer.Argument(
         help="Group to move hosts to.",
+        show_default=False,
     ),
     rollback: bool = typer.Option(
         True,
@@ -338,7 +380,10 @@ def move_hosts(
 @app.command("show_hostgroup", rich_help_panel=HELP_PANEL)
 def show_hostgroup(
     ctx: typer.Context,
-    hostgroup: str = typer.Argument(help="Name of host group."),
+    hostgroup: str = typer.Argument(
+        help="Name of host group.",
+        show_default=False,
+    ),
 ) -> None:
     """Show details of a host group."""
     from zabbix_cli.commands.results.hostgroup import HostGroupResult
@@ -368,7 +413,8 @@ def show_hostgroup(
 )
 def show_hostgroups(
     name: Optional[str] = typer.Argument(
-        None, help="Name of host group(s). Comma-separated. Supports wildcards."
+        help="Name of host group(s). Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
     select_hosts: bool = typer.Option(
         True, "--hosts/--no-hosts", help="Show hosts in each host group."
@@ -401,8 +447,9 @@ def show_hostgroups(
 
 @app.command("show_hostgroup_permissions", rich_help_panel=HELP_PANEL)
 def show_hostgroup_permissions(
-    hostgroups: Optional[str] = typer.Argument(
-        None, help="Host group name(s). Comma-separated. Supports wildcards."
+    hostgroups: str = typer.Argument(
+        help="Host group name(s). Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
 ) -> None:
     """Show usergroups with permissions for the given hostgroup.

--- a/zabbix_cli/commands/item.py
+++ b/zabbix_cli/commands/item.py
@@ -38,6 +38,7 @@ def show_last_values(
     ctx: typer.Context,
     item: str = typer.Argument(
         help="Item names or IDs. Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
     group: bool = typer.Option(
         False, "--group", is_flag=True, help="Group items with the same value."

--- a/zabbix_cli/commands/macro.py
+++ b/zabbix_cli/commands/macro.py
@@ -36,25 +36,30 @@ def fmt_macro_name(macro: str) -> str:
     examples=[
         Example(
             "Create a macro named {$SNMP_COMMUNITY} for a host",
-            "define_host_usermacro 'foo.example.com' '{$SNMP_COMMUNITY}' 'public'",
+            "define_host_usermacro foo.example.com '{$SNMP_COMMUNITY}' public",
         ),
         Example(
             "Create a macro named {$SITE_URL} for a host (automatic name conversion)",
-            "define_host_usermacro 'foo.example.com' 'site_url' 'https://example.com'",
+            "define_host_usermacro foo.example.com site_url https://example.com",
         ),
     ],
 )
 def define_host_usermacro(
     # NOTE: should this use old style args?
-    hostname: str = typer.Argument(help="Host to define macro for."),
+    hostname: str = typer.Argument(
+        help="Host to define macro for.", show_default=False
+    ),
     macro_name: str = typer.Argument(
         help=(
             "Name of macro. "
             "Names will be converted to the Zabbix format, "
-            "i.e. [value]site_url[/] becomes [code]{$SITE_URL}[/]."
+            "i.e. [value]site_url[/] becomes [value]{$SITE_URL}[/]."
         ),
+        show_default=False,
     ),
-    macro_value: str = typer.Argument(help="Default value of macro."),
+    macro_value: str = typer.Argument(
+        help="Default value of macro.", show_default=False
+    ),
 ) -> None:
     """Create or update a host usermacro."""
     from zabbix_cli.models import Result
@@ -85,7 +90,10 @@ def define_host_usermacro(
 
 @app.command(name="show_host_usermacros", rich_help_panel=HELP_PANEL, hidden=False)
 def show_host_usermacros(
-    hostname_or_id: str = typer.Argument(help="Hostname or ID to show macros for"),
+    hostname_or_id: str = typer.Argument(
+        help="Hostname or ID to show macros for",
+        show_default=False,
+    ),
 ) -> None:
     """Show all macros defined for a host."""
     from zabbix_cli.commands.results.macro import ShowHostUserMacrosResult
@@ -110,8 +118,9 @@ def show_usermacro_host_list(
     usermacro: str = typer.Argument(
         help=(
             "Name of macro to find hosts with. "
-            "Application will automatically format macro names, e.g. `site_url` becomes `{$SITE_URL}`."
+            "Macro names are automatically formatted, e.g. [value]site_url[/] becomes [value]{$SITE_URL}[/]."
         ),
+        show_default=False,
     ),
     limit: Optional[int] = get_limit_option(),
 ) -> None:
@@ -153,8 +162,8 @@ def show_usermacro_host_list(
 @app.command("define_global_macro", rich_help_panel=HELP_PANEL)
 def define_global_macro(
     ctx: typer.Context,
-    name: str = typer.Argument(help="Name of the macro"),
-    value: str = typer.Argument(help="Value of the macro"),
+    name: str = typer.Argument(help="Name of the macro", show_default=False),
+    value: str = typer.Argument(help="Value of the macro", show_default=False),
 ) -> None:
     """Create a global macro."""
     from zabbix_cli.commands.results.macro import GlobalMacroResult
@@ -210,7 +219,8 @@ def show_global_macros(ctx: typer.Context) -> None:
 def show_usermacro_template_list(
     ctx: typer.Context,
     macro_name: str = typer.Argument(
-        help="Name of the macro to find templates with. Automatically formatted."
+        help="Name of the macro to find templates with. Automatically formatted.",
+        show_default=False,
     ),
     limit: Optional[int] = get_limit_option(),
 ) -> None:

--- a/zabbix_cli/commands/maintenance.py
+++ b/zabbix_cli/commands/maintenance.py
@@ -6,6 +6,7 @@ import typer
 
 from zabbix_cli.app import Example
 from zabbix_cli.app import app
+from zabbix_cli.commands.common.args import OPTION_LIMIT
 from zabbix_cli.output.console import exit_err
 from zabbix_cli.output.prompts import str_prompt_optional
 from zabbix_cli.output.render import render_result
@@ -38,6 +39,7 @@ def create_maintenance_definition(
     ctx: typer.Context,
     name: str = typer.Argument(
         help="Maintenance name.",
+        show_default=False,
     ),
     description: Optional[str] = typer.Option(
         None,
@@ -110,7 +112,8 @@ def create_maintenance_definition(
 def remove_maintenance_definition(
     ctx: typer.Context,
     maintenance_id: str = typer.Argument(
-        help="ID(s) of maintenance(s) to remove. Comma-separated."
+        help="ID(s) of maintenance(s) to remove. Comma-separated.",
+        show_default=False,
     ),
 ) -> None:
     """Remove a maintenance definition."""
@@ -202,7 +205,9 @@ def show_maintenance_periods(
     maintenance_id: Optional[str] = typer.Argument(
         None,
         help="Maintenance IDs. Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
+    limit: int = OPTION_LIMIT,
 ) -> None:
     """Show maintenance periods for one or more maintenance definitions.
 
@@ -213,7 +218,9 @@ def show_maintenance_periods(
 
     mids = parse_list_arg(maintenance_id)
     with app.status("Fetching maintenance periods..."):
-        maintenances = app.state.client.get_maintenances(maintenance_ids=mids)
+        maintenances = app.state.client.get_maintenances(
+            maintenance_ids=mids, limit=limit
+        )
 
     render_result(
         AggregateResult(

--- a/zabbix_cli/commands/problem.py
+++ b/zabbix_cli/commands/problem.py
@@ -22,7 +22,10 @@ HELP_PANEL = "Problem"
 @app.command(name="acknowledge_event", rich_help_panel=HELP_PANEL)
 def acknowledge_event(
     ctx: typer.Context,
-    event_ids: str = typer.Argument(help="Comma-separated list of event ID(s)"),
+    event_ids: str = typer.Argument(
+        help="Comma-separated list of event ID(s)",
+        show_default=False,
+    ),
     message: str = typer.Option(
         "[Zabbix-CLI] Acknowledged via acknowledge_events",
         "--message",

--- a/zabbix_cli/commands/proxy.py
+++ b/zabbix_cli/commands/proxy.py
@@ -83,10 +83,18 @@ def group_hosts_by_proxy(
 def update_host_proxy(
     ctx: typer.Context,
     hostname: str = typer.Argument(
-        help="Hostnames. Comma-separated Supports wildcards."
+        help="Hostnames. Comma-separated Supports wildcards.",
+        show_default=False,
     ),
-    proxy: str = typer.Argument(help="Proxy name. Supports wildcards."),
-    dryrun: bool = typer.Option(False, help="Preview changes", is_flag=True),
+    proxy: str = typer.Argument(
+        help="Proxy name. Supports wildcards.",
+        show_default=False,
+    ),
+    dryrun: bool = typer.Option(
+        False,
+        help="Preview changes",
+        is_flag=True,
+    ),
 ) -> None:
     """Assign hosts to a proxy.
 
@@ -142,7 +150,8 @@ def update_host_proxy(
 def clear_host_proxy(
     ctx: typer.Context,
     hostname: str = typer.Argument(
-        help="Hostnames. Comma-separated Supports wildcards."
+        help="Hostnames. Comma-separated Supports wildcards.",
+        show_default=False,
     ),
     dryrun: bool = typer.Option(False, help="Preview changes", is_flag=True),
 ) -> None:
@@ -208,8 +217,14 @@ def clear_host_proxy(
 )
 def move_proxy_hosts(
     ctx: typer.Context,
-    proxy_src: str = typer.Argument(None, help="Proxy to move hosts from."),
-    proxy_dst: str = typer.Argument(None, help="Proxy to move hosts to."),
+    proxy_src: str = typer.Argument(
+        help="Proxy to move hosts from.",
+        show_default=False,
+    ),
+    proxy_dst: str = typer.Argument(
+        help="Proxy to move hosts to.",
+        show_default=False,
+    ),
     # Prefer --filter over positional arg
     host_filter: Optional[str] = typer.Option(
         None, "--filter", help="Regex pattern of hosts to move."
@@ -369,9 +384,13 @@ def load_balance_proxy_hosts(
 def update_hostgroup_proxy(
     ctx: typer.Context,
     hostgroup: str = typer.Argument(
-        help="Host group(s). Comma-separated. Supports wildcards."
+        help="Host group(s). Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
-    proxy: str = typer.Argument(help="Proxy to assign. Supports wildcards."),
+    proxy: str = typer.Argument(
+        help="Proxy to assign. Supports wildcards.",
+        show_default=False,
+    ),
     dryrun: bool = typer.Option(False, help="Preview changes.", is_flag=True),
 ) -> None:
     """Assign a proxy to all hosts in one or more host groups."""
@@ -409,14 +428,16 @@ def update_hostgroup_proxy(
 @app.command(name="show_proxies", rich_help_panel=HELP_PANEL)
 def show_proxies(
     ctx: typer.Context,
+    name_or_id: Optional[str] = typer.Argument(
+        None,
+        help="Filter by proxy name or ID. Comma-separated. Supports wildcards.",
+        show_default=False,
+    ),
     hosts: bool = typer.Option(
         False,
         "--hosts",
         help="Show hostnames of each host.",
         is_flag=True,
-    ),
-    name_or_id: Optional[str] = typer.Argument(
-        None, help="Filter by proxy name or ID. Comma-separated. Supports wildcards."
     ),
 ) -> None:
     """Show all proxies.
@@ -462,7 +483,9 @@ def show_proxies(
 def show_proxy_groups(
     ctx: typer.Context,
     name_or_id: Optional[str] = typer.Argument(
-        None, help="Filter by proxy name or ID. Comma-separated. Supports wildcards."
+        None,
+        help="Filter by proxy name or ID. Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
     proxies: Optional[str] = typer.Option(
         None,
@@ -505,12 +528,22 @@ def show_proxy_groups(
 )
 def add_proxy_to_group(
     ctx: typer.Context,
-    name_or_id: str = typer.Argument(help="Name or ID of proxy to add."),
-    proxy_group: str = typer.Argument(
-        help="Name or ID of proxy group to add proxy to."
+    name_or_id: str = typer.Argument(
+        help="Name or ID of proxy to add.",
+        show_default=False,
     ),
-    local_address: Optional[str] = typer.Argument(help="Address for active agents."),
-    local_port: Optional[str] = typer.Argument(help="Address for active agents."),
+    proxy_group: str = typer.Argument(
+        help="Name or ID of proxy group to add proxy to.",
+        show_default=False,
+    ),
+    local_address: Optional[str] = typer.Argument(
+        help="Address for active agents.",
+        show_default=False,
+    ),
+    local_port: Optional[str] = typer.Argument(
+        help="Address for active agents.",
+        show_default=False,
+    ),
 ) -> None:
     """Add a proxy to a proxy group.
 
@@ -538,7 +571,10 @@ def add_proxy_to_group(
 @app.command(name="remove_proxy_from_group", rich_help_panel=HELP_PANEL)
 def remove_proxy_from_group(
     ctx: typer.Context,
-    name_or_id: str = typer.Argument(help="Name or ID of proxy to remove."),
+    name_or_id: str = typer.Argument(
+        help="Name or ID of proxy to remove.",
+        show_default=False,
+    ),
 ) -> None:
     """Remove a proxy from a proxy group."""
     ensure_proxy_group_support()
@@ -556,9 +592,13 @@ def remove_proxy_from_group(
 def update_hostgroup_proxygroup(
     ctx: typer.Context,
     hostgroup: str = typer.Argument(
-        help="Host group(s). Comma-separated. Supports wildcards."
+        help="Host group(s). Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
-    proxygroup: str = typer.Argument(help="Proxy group to assign. Supports wildcards."),
+    proxygroup: str = typer.Argument(
+        help="Proxy group to assign. Supports wildcards.",
+        show_default=False,
+    ),
     dryrun: bool = typer.Option(False, help="Preview changes.", is_flag=True),
 ) -> None:
     """Assign a proxy group to all hosts in one or more host groups."""
@@ -601,7 +641,8 @@ def update_hostgroup_proxygroup(
 def show_proxy_group_hosts(
     ctx: typer.Context,
     proxygroup: str = typer.Argument(
-        help="Proxy group name or ID. Supports wildcards."
+        help="Proxy group name or ID. Supports wildcards.",
+        show_default=False,
     ),
 ) -> None:
     """Show all hosts in a proxy group."""

--- a/zabbix_cli/commands/template.py
+++ b/zabbix_cli/commands/template.py
@@ -104,13 +104,16 @@ def _handle_template_arg(
 
 
 ARG_TEMPLATE_NAMES_OR_IDS = typer.Argument(
-    help="Template names or IDs. Comma-separated. Supports wildcards."
+    help="Template names or IDs. Comma-separated. Supports wildcards.",
+    show_default=False,
 )
 ARG_HOSTNAMES_OR_IDS = typer.Argument(
-    help="Hostnames or IDs. Comma-separated. Supports wildcards."
+    help="Hostnames or IDs. Comma-separated. Supports wildcards.",
+    show_default=False,
 )
 ARG_GROUP_NAMES_OR_IDS = typer.Argument(
-    help="Host/template group names or IDs. Comma-separated. Supports wildcards."
+    help="Host/template group names or IDs. Comma-separated. Supports wildcards.",
+    show_default=False,
 )
 
 
@@ -535,7 +538,8 @@ def remove_template_from_group(
 def show_template(
     ctx: typer.Context,
     template_name: str = typer.Argument(
-        help="Template name or ID. Names support wildcards."
+        help="Template name or ID. Names support wildcards.",
+        show_default=False,
     ),
 ) -> None:
     """Show a template."""
@@ -586,7 +590,8 @@ def show_templates(
 def show_items(
     ctx: typer.Context,
     template_name: str = typer.Argument(
-        help="Template name or ID. Supports wildcards."
+        help="Template name or ID. Supports wildcards.",
+        show_default=False,
     ),
 ) -> None:
     """Show a template's items."""

--- a/zabbix_cli/commands/templategroup.py
+++ b/zabbix_cli/commands/templategroup.py
@@ -43,7 +43,10 @@ if TYPE_CHECKING:
 )
 def create_templategroup(
     ctx: typer.Context,
-    templategroup: str = typer.Argument(help="Name of the group."),
+    templategroup: str = typer.Argument(
+        help="Name of the group.",
+        show_default=False,
+    ),
     rw_groups: Optional[str] = typer.Option(
         None,
         help="User group(s) to give read/write permissions. Comma-separated.",
@@ -126,7 +129,10 @@ def create_templategroup(
 @app.command("remove_templategroup", rich_help_panel=HELP_PANEL)
 def remove_templategroup(
     ctx: typer.Context,
-    templategroup: str = typer.Argument(help="Name of the group to delete."),
+    templategroup: str = typer.Argument(
+        help="Name of the group to delete.",
+        show_default=False,
+    ),
 ) -> None:
     """Delete a template group.
 
@@ -148,7 +154,8 @@ def remove_templategroup(
 def show_templategroup(
     ctx: typer.Context,
     templategroup: str = typer.Argument(
-        help="Name of the group to show. Supports wildcards."
+        help="Name of the group to show. Supports wildcards.",
+        show_default=False,
     ),
     templates: bool = typer.Option(
         True,
@@ -192,7 +199,9 @@ def show_templategroup(
 def show_templategroups(
     ctx: typer.Context,
     name: Optional[str] = typer.Argument(
-        None, help="Name of template group(s). Comma-separated. Supports wildcards."
+        None,
+        help="Name of template group(s). Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
     templates: bool = typer.Option(
         True,
@@ -241,9 +250,13 @@ def show_templategroups(
 @app.command("extend_templategroup", rich_help_panel=HELP_PANEL)
 def extend_templategroup(
     ctx: typer.Context,
-    src_group: str = typer.Argument(help="Group to get templates from."),
+    src_group: str = typer.Argument(
+        help="Group to get templates from.",
+        show_default=False,
+    ),
     dest_group: str = typer.Argument(
-        help="Group(s) to add templates to. Comma-separated. Supports wildcards."
+        help="Group(s) to add templates to. Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
     dryrun: bool = typer.Option(
         False,
@@ -295,9 +308,11 @@ def extend_templategroup(
 def move_templates(
     src_group: str = typer.Argument(
         help="Group to move templates from.",
+        show_default=False,
     ),
     dest_group: str = typer.Argument(
         help="Group to move templates to.",
+        show_default=False,
     ),
     rollback: bool = typer.Option(
         True,

--- a/zabbix_cli/commands/user.py
+++ b/zabbix_cli/commands/user.py
@@ -54,7 +54,10 @@ def get_random_password() -> str:
 @app.command("create_user", rich_help_panel=HELP_PANEL)
 def create_user(
     ctx: typer.Context,
-    username: str = typer.Argument(help="Username of the user to create."),
+    username: str = typer.Argument(
+        help="Username of the user to create.",
+        show_default=False,
+    ),
     first_name: Optional[str] = typer.Option(
         None, "--firstname", help="First name of the user to create."
     ),
@@ -166,7 +169,10 @@ def create_user(
 )
 def update_user(
     ctx: typer.Context,
-    username: str = typer.Argument(help="Username of the user to update"),
+    username: str = typer.Argument(
+        help="Username of the user to update",
+        show_default=False,
+    ),
     first_name: Optional[str] = typer.Option(
         None, "--firstname", help="New first name."
     ),
@@ -241,7 +247,10 @@ def update_user(
 @app.command("remove_user", rich_help_panel=HELP_PANEL)
 def remove_user(
     ctx: typer.Context,
-    username: str = typer.Argument(help="Username to remove."),
+    username: str = typer.Argument(
+        help="Username to remove.",
+        show_default=False,
+    ),
 ) -> None:
     """Remove a user."""
     from zabbix_cli.models import Result
@@ -259,7 +268,10 @@ def remove_user(
 @app.command("show_user", rich_help_panel=HELP_PANEL)
 def show_user(
     ctx: typer.Context,
-    username: str = typer.Argument(help="Username of user"),
+    username: str = typer.Argument(
+        help="Username of user",
+        show_default=False,
+    ),
 ) -> None:
     """Show a user."""
     user = app.state.client.get_user(username)
@@ -276,7 +288,9 @@ class UserSorting(StrEnum):
 def show_users(
     ctx: typer.Context,
     username_or_id: Optional[str] = typer.Argument(
-        None, help="Filter by username or ID. Supports wildcards."
+        None,
+        help="Filter by username or ID. Supports wildcards.",
+        show_default=False,
     ),
     role: Optional[UserRole] = typer.Option(
         None,
@@ -467,10 +481,13 @@ def create_notification_user(
 @app.command("add_user_to_usergroup", rich_help_panel=HELP_PANEL)
 def add_user_to_usergroup(
     ctx: typer.Context,
-    usernames: str = typer.Argument(help="Usernames to add. Comma-separated."),
-    usergroups: Optional[str] = typer.Argument(
-        None,
+    usernames: str = typer.Argument(
+        help="Usernames to add. Comma-separated.",
+        show_default=False,
+    ),
+    usergroups: str = typer.Argument(
         help="User groups to add the users to. Comma-separated.",
+        show_default=False,
     ),
 ) -> None:
     """Add users to usergroups.
@@ -503,9 +520,13 @@ def add_user_to_usergroup(
 @app.command("remove_user_from_usergroup", rich_help_panel=HELP_PANEL)
 def remove_user_from_usergroup(
     ctx: typer.Context,
-    usernames: str = typer.Argument(help="Usernames to remove. Comma-separated."),
+    usernames: str = typer.Argument(
+        help="Usernames to remove. Comma-separated.",
+        show_default=False,
+    ),
     usergroups: str = typer.Argument(
         help="User groups to remove the users from. Comma-separated.",
+        show_default=False,
     ),
 ) -> None:
     """Remove users from usergroups.
@@ -538,7 +559,10 @@ def remove_user_from_usergroup(
 @app.command("create_usergroup", rich_help_panel=HELP_PANEL)
 def create_usergroup(
     ctx: typer.Context,
-    usergroup: str = typer.Argument(help="Name of the user group to create."),
+    usergroup: str = typer.Argument(
+        help="Name of the user group to create.",
+        show_default=False,
+    ),
     gui_access: GUIAccess = typer.Option(
         GUIAccess.DEFAULT.value, "--gui", help="GUI access for the group."
     ),
@@ -623,6 +647,7 @@ def show_usergroup(
     ctx: typer.Context,
     usergroup: str = typer.Argument(
         help="Name or ID of the user group(s) to show. Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
     sort: UsergroupSorting = OPTION_SORT_UGROUPS,
 ) -> None:
@@ -653,6 +678,7 @@ def show_usergroups(
     usergroup: Optional[str] = typer.Argument(
         None,
         help="Name or ID of the user group(s) to show. Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
     sort: UsergroupSorting = OPTION_SORT_UGROUPS,
     limit: Optional[int] = OPTION_LIMIT,
@@ -705,7 +731,8 @@ def _do_show_usergroups(
 def show_usergroup_permissions(
     ctx: typer.Context,
     usergroup: str = typer.Argument(
-        help="Name of user group. Comma-separated. Supports wildcards."
+        help="Name of user group. Comma-separated. Supports wildcards.",
+        show_default=False,
     ),
     sort: UsergroupSorting = OPTION_SORT_UGROUPS,
 ) -> None:
@@ -748,7 +775,10 @@ def show_usergroup_permissions(
 @app.command("update_usergroup_permissions", rich_help_panel=HELP_PANEL)
 def add_usergroup_permissions(
     ctx: typer.Context,
-    usergroup: str = typer.Argument(help="User group to give permissions to."),
+    usergroup: str = typer.Argument(
+        help="User group to give permissions to.",
+        show_default=False,
+    ),
     hostgroups: Optional[str] = typer.Option(
         None,
         "--hostgroup",

--- a/zabbix_cli/pyzabbix/client.py
+++ b/zabbix_cli/pyzabbix/client.py
@@ -2103,6 +2103,7 @@ class ZabbixAPI:
         hostgroups: Optional[List[HostGroup]] = None,
         hosts: Optional[List[Host]] = None,
         name: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> List[Maintenance]:
         params: ParamsType = {
             "output": "extend",
@@ -2121,6 +2122,7 @@ class ZabbixAPI:
             filter_params["name"] = name
         if filter_params:
             params["filter"] = filter_params
+        params = add_common_params(params, limit=limit)
         resp = self.maintenance.get(**params)
         return [Maintenance(**mt) for mt in resp]
 


### PR DESCRIPTION
This PR hides the default argument (`default:None`) from the help text of required positional arguments. These positional arguments per definition don't have a default, since they are _required_, and thus it makes no sense to show a `None` default that will never be used.