### PR TITLE
Create log directory when accessed

### DIFF
--- a/zabbix_cli/config/model.py
+++ b/zabbix_cli/config/model.py
@@ -49,10 +49,10 @@ from zabbix_cli.config.utils import load_config_toml
 from zabbix_cli.dirs import DATA_DIR
 from zabbix_cli.dirs import EXPORT_DIR
 from zabbix_cli.dirs import LOGS_DIR
-from zabbix_cli.dirs import mkdir_if_not_exists
 from zabbix_cli.exceptions import ConfigError
 from zabbix_cli.logs import LogLevelStr
 from zabbix_cli.pyzabbix.enums import ExportFormat
+from zabbix_cli.utils.fs import mkdir_if_not_exists
 
 
 class BaseModel(PydanticBaseModel):

--- a/zabbix_cli/dirs.py
+++ b/zabbix_cli/dirs.py
@@ -14,7 +14,6 @@ from platformdirs import PlatformDirs
 
 from zabbix_cli.__about__ import APP_NAME
 from zabbix_cli.__about__ import AUTHOR
-from zabbix_cli.exceptions import ZabbixCLIFileError
 
 logger = logging.getLogger(__name__)
 
@@ -54,20 +53,6 @@ DIRS = [
     # Exports directory is created on demand
     Directory("Exports", EXPORT_DIR, create=False),
 ]
-
-
-def mkdir_if_not_exists(path: Path) -> None:
-    """Create a directory if it does not exist.
-    Returns the path if it was created, otherwise None.
-    """
-    if path.exists():
-        return
-    try:
-        path.mkdir(parents=True, exist_ok=True)
-    except Exception as e:
-        raise ZabbixCLIFileError(f"Failed to create directory {path}: {e}") from e
-    else:
-        logger.info(f"Created directory: {path}")
 
 
 def init_directories() -> None:

--- a/zabbix_cli/logs.py
+++ b/zabbix_cli/logs.py
@@ -127,7 +127,10 @@ def get_file_handler_safe(filename: Path) -> logging.Handler:
     """Return a FileHandler that does not fail if the file cannot be opened.
 
     Returns a stderr StreamHandler if the file cannot be opened."""
+    from zabbix_cli.utils.fs import mkdir_if_not_exists
+
     try:
+        mkdir_if_not_exists(filename.parent)
         return logging.FileHandler(filename)
     except Exception as e:
         logger.error("Could not open log file %s for writing: %s", filename, e)

--- a/zabbix_cli/utils/fs.py
+++ b/zabbix_cli/utils/fs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
 import subprocess
@@ -10,6 +11,8 @@ from typing import Optional
 from zabbix_cli.exceptions import ZabbixCLIError
 from zabbix_cli.exceptions import ZabbixCLIFileError
 from zabbix_cli.exceptions import ZabbixCLIFileNotFoundError
+
+logger = logging.getLogger(__name__)
 
 
 def read_file(file: Path) -> str:
@@ -61,6 +64,21 @@ def open_directory(
             if not force:
                 return
         subprocess.run([command or "xdg-open", spath])
+
+
+def mkdir_if_not_exists(path: Path) -> None:
+    """Create a directory for a given path if it does not exist.
+
+    Returns the path if it was created, otherwise None.
+    """
+    if path.exists():
+        return
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        raise ZabbixCLIFileError(f"Failed to create directory {path}: {e}") from e
+    else:
+        logger.info(f"Created directory: {path}")
 
 
 def sanitize_filename(filename: str) -> str:


### PR DESCRIPTION
This should silence errors in CI when attempting to set up logging for the docs workflow.