### PR TITLE
Build in Ubuntu 20.04 for glibc compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
         python-version:
           - '3.12'
     steps:


### PR DESCRIPTION
Per the [pyinstaller docs](https://pyinstaller.org/en/v6.10.0/usage.html#making-gnu-linux-apps-forward-compatible), we should build in the oldest possible Linux version we want to support due to glibc version compatibility. Building with the latest glibc version makes the binary incompatible with older systems. With this change, we support glibc versions down to 2.31 [per this table](https://gist.github.com/richardlau/6a01d7829cc33ddab35269dacc127680).