### PR TITLE
Use centos 8 image to build pyinstaller binary for Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version:
           - '3.12'
+        include:
+          - os: ubuntu-latest
+            container: centos:8
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This is a bit of a hail mary inspired by a brief ChatGPT conversation about ensuring RHEL 8 compatibility for the built binary. Let's try it out.