### PR TITLE
Fix `--help` requiring a config file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Plugin support. See the [plugins documentation](https://unioslo.github.io/zabbix-cli/plugins/) for more information.
 
+### Changed
+
+- `--config` now always creates the config file at the given location if it doesn't exist.
+- `show_config` now shows the absolute path to the active configuration file.
+
 ## 3.0.3
 
 ### Added

--- a/docs/plugins/external-plugins.md
+++ b/docs/plugins/external-plugins.md
@@ -91,3 +91,15 @@ However, the option is there if you want to provide users with additional config
 
 !!! note
     If rewriting a local plugin as an external one, remember to remove the `module` key from the plugin's configuration.
+
+## Installing the plugin
+
+How to install the plugins depends on how Zabbix-CLI is installed. The plugin must be installed in the same Python environment as Zabbix-CLI, which is different with each installation method.
+
+### uv
+
+If Zabbix-CLI is installed with `uv tool`, the plugin can be installed with `uv tool install --with`:
+
+```bash
+uv tool install --with your_plugin_name
+```

--- a/zabbix_cli/commands/cli.py
+++ b/zabbix_cli/commands/cli.py
@@ -43,7 +43,7 @@ def show_config(ctx: typer.Context) -> None:
     config = app.state.config
     print_toml(config.as_toml())
     if config.config_path:
-        info(f"Config file: {config.config_path}")
+        info(f"Config file: {config.config_path.absolute()}")
 
 
 class DirectoryType(Enum):

--- a/zabbix_cli/config/utils.py
+++ b/zabbix_cli/config/utils.py
@@ -64,7 +64,7 @@ def find_config(
     return None
 
 
-def get_config(filename: Optional[Path] = None) -> Config:
+def get_config(filename: Optional[Path] = None, init: bool = False) -> Config:
     """Get a configuration object.
 
     Args:
@@ -75,7 +75,7 @@ def get_config(filename: Optional[Path] = None) -> Config:
     """
     from zabbix_cli.config.model import Config
 
-    return Config.from_file(find_config(filename))
+    return Config.from_file(filename, init=init)
 
 
 def init_config(

--- a/zabbix_cli/main.py
+++ b/zabbix_cli/main.py
@@ -136,14 +136,12 @@ def main_callback(
         return
 
     state = get_state()
-    if should_skip_configuration(ctx) or state.is_config_loaded:
-        conf = state.config  # uses a default config
-    else:
-        conf = get_config(config_file)
+    if not should_skip_configuration(ctx) and not state.is_config_loaded:
+        state.config = get_config(config_file, init=True)
 
     # Config overrides are always applied
     if output_format is not None:
-        conf.app.output_format = output_format
+        state.config.app.output_format = output_format
 
     if state.repl:
         return  # In REPL already; no need to re-configure.
@@ -222,8 +220,8 @@ def _parse_config_arg() -> Optional[Path]:
 
         exit_err("No value provided for --config/-c argument.")
 
-    # Remove the argument and its value from sys.argv
-    sys.argv = sys.argv[:index] + sys.argv[index + 2 :]
+    # # Remove the argument and its value from sys.argv
+    # sys.argv = sys.argv[:index] + sys.argv[index + 2 :]
     return Path(conf)
 
 
@@ -236,7 +234,7 @@ def main() -> int:
     # - configure console output
     # - load local plugins (defined in the config)
     conf = _parse_config_arg()
-    config = get_config(conf)
+    config = get_config(conf, init=False)
     state.config = config
     app.load_plugins(state.config)
 

--- a/zabbix_cli/state.py
+++ b/zabbix_cli/state.py
@@ -126,13 +126,16 @@ class State:
     def config(self, config: Config) -> None:
         """Set the configuration object and update active configuration of
         loggers, consoles, etc."""
+        from zabbix_cli.config.model import Config
         from zabbix_cli.logs import configure_logging
         from zabbix_cli.output.console import configure_console
 
         self._config = config
         configure_logging(config.logging)
         configure_console(config)
-        self._config_loaded = True
+        # HACK: don't consider using sample config as "loaded".
+        # Signals that main callback should create a new config file.
+        self._config_loaded = config != Config.sample_config()
 
     @property
     def is_config_loaded(self) -> bool:


### PR DESCRIPTION
#216 made it so we load the config on startup before launching the Typer app. This had the unfortunate side effect of requiring a config to run `zabbix-cli --help`, which is not ideal. This PR defers the creation of the config until we are inside the main callback.