### PR TITLE
Publish PyPI aliased package

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- ## [Unreleased] -->
 
+## 3.1.1
+
+### Added
+
+- Publish to PyPI.
+
 ## 3.1.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Zabbix-cli
 
-<!-- Activate badges when we publish to PyPI -->
-<!-- [![PyPI](https://img.shields.io/pypi/v/zabbix-cli)](https://pypi.org/project/zabbix-cli/)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/zabbix-cli)](https://pypi.org/project/zabbix-cli/)
-![PyPI - License](https://img.shields.io/pypi/l/zabbix-cli)(https://pypi.org/project/zabbix-cli/) -->
+[![PyPI](https://img.shields.io/pypi/v/zabbix-cli-uio)](https://pypi.org/project/zabbix-cli-uio/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/zabbix-cli-uio)](<https://pypi.org/project/zabbix-cli-uio/>)
+[![PyPI - License](https://img.shields.io/pypi/l/zabbix-cli-uio)](<https://pypi.org/project/zabbix-cli-uio/>)
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/unioslo/zabbix-cli/test.yml?branch=master&label=tests)
 
 <p align="center">
@@ -43,22 +42,27 @@ The manual is available online at <https://unioslo.github.io/zabbix-cli/>.
 
 ### From source
 
-[uv](https://github.com/astral-sh/uv):
+#### pip(x)
 
 ```bash
-uv tool install git+https://github.com/unioslo/zabbix-cli.git@master
-
-# Or if you just want to try out the CLI without installing it
-uvx --from git+https://github.com/unioslo/zabbix-cli.git@master zabbix-cli
+pipx install zabbix-cli-uio
 ```
 
-pip(x):
+#### [uv](https://github.com/astral-sh/uv)
 
 ```bash
-pipx install git+https://github.com/unioslo/zabbix-cli.git@master
+uv tool install zabbix-cli-uio
 ```
 
-We are in the process of acquiring the name `zabbix-cli` on PyPI. Until then, installation from the GitHub repository is the only option when installing as a Python package.
+If you just want to try out the CLI without installing it:
+
+```bash
+
+uvx --from zabbix-cli-uio zabbix-cli
+```
+
+> [!NOTE]
+> We are in the process of acquiring the name `zabbix-cli` on PyPI. Until then, installation must be done via the mirror package `zabbix-cli-uio`.
 
 ### Homebrew
 

--- a/docs/.includes/quick-install.md
+++ b/docs/.includes/quick-install.md
@@ -4,14 +4,14 @@
 
     ```bash
     pip install pipx
-    pipx install git+https://github.com/unioslo/zabbix-cli.git@master
+    pipx install zabbix-cli-uio
     ```
 
     This will install `zabbix-cli` in an isolated environment and make it available on your system path.
 
 
     !!! note
-        We are in the process of acquiring the unmaintained PyPI package name `zabbixcli`, which will allow us to publish this package on PyPI under the name `zabbix-cli`. Until then, the package is only available on GitHub.
+        We are in the process of acquiring the unmaintained PyPI package name `zabbixcli`, which will allow us to publish this package on PyPI under the name `zabbix-cli`. Until then, installation must be done via the aliased package name `zabbix-cli-uio`.
 
     {% if install_expand is defined and install_expand == true %}
     ### Multiple installed versions
@@ -23,7 +23,7 @@
     If you prefer to install the package with `pip`, you can do so with the following command:
 
     ```bash
-    pip install git+https://github.com/unioslo/zabbix-cli.git@master
+    pip install zabbix-cli-uio
     ```
 
     This will install `zabbix-cli` in your user environment.
@@ -37,7 +37,7 @@
     ```
 
     !!! warning
-        The Homebrew package is not maintained by the author of `zabbix-cli`. It may be outdated or contain bugs. For the most up to date version, follow the installation instructions for pipx.
+        The Homebrew package is maintained by a third party. It may be outdated or contain bugs. For the most up to date version, follow the installation instructions for pipx.
 
 === "PyInstaller Binary"
 

--- a/docs/plugins/external-plugins.md
+++ b/docs/plugins/external-plugins.md
@@ -113,14 +113,14 @@ extra_option_2 = 42
 
 ## Installation
 
-How to install the plugins depends on how Zabbix-CLI is installed. The plugin must be installed in the same Python environment as Zabbix-CLI, which is different with each installation method.
+How to install the plugins depends on how Zabbix-CLI is installed. The plugin must be installed in the same Python environment as Zabbix-CLI, which is different for each installation method.
 
 ### uv
 
 `uv` can install plugins using the same `uv tool install` command, but with the `--with` flag:
 
 ```bash
-uv tool install git+https://github.com/unioslo/zabbix-cli.git@master --with my_plugin
+uv tool install zabbix-cli-uio --with my_plugin
 ```
 
 ### pipx
@@ -128,8 +128,8 @@ uv tool install git+https://github.com/unioslo/zabbix-cli.git@master --with my_p
 `pipx` Zabbix-CLI installations require the plugin to be injected into the environment:
 
 ```bash
-pipx install git+https://github.com/unioslo/zabbix-cli.git@master
-pipx inject zabbix-cli my_plugin
+pipx install zabbix-cli-uio
+pipx inject zabbix-cli-uio my_plugin
 ```
 
 ### pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 description = "ZABBIX-CLI - Zabbix terminal client"
-name = "zabbix-cli"
+name = "zabbix-cli-uio"
 readme = "README.md"
 requires-python = ">=3.8"
 license = "GPL-3.0-or-later"
@@ -66,6 +66,9 @@ build = ["pyinstaller", "build"]
 [tool.hatch.version]
 path = "zabbix_cli/__about__.py"
 
+[tool.hatch.build.targets.wheel]
+packages = ["zabbix_cli"]
+
 [tool.hatch.build.targets.app]
 pyapp-version = "0.12.0"
 python-version = "3.11"
@@ -77,7 +80,7 @@ dependencies = [
   # optional dependencies
   "ruff",
   "pyright",
-  "zabbix_cli[test]",
+  "zabbix-cli-uio[test]",
 ]
 installer = "uv"
 


### PR DESCRIPTION
This PR changes the name of the package (temporarily) to `zabbix-cli-uio`, so that we can publish it to PyPI. This does not change any import paths - only its name on PyPI and in the package metadata itself.

In the future, when we obtain the name `zabbix-cli`, we must rename this package back to `zabbix-cli` and create a new repository for `zabbix-cli-uio`, which will be an empty package with a single dependency: `zabbix-cli`.