### PR TITLE
Refactor bulk.py

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- released start -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Configurable error handling modes for bulk mode under `app.bulk_mode`:
+  - `strict`: Stop on first error.
+  - `continue`: Continue on command execution error, report at the end.
+  - `ignore`: Ignore all errors, including command file parsing errors.
 
 ## [3.1.3]
 

--- a/docs/guide/bulk.md
+++ b/docs/guide/bulk.md
@@ -1,0 +1,37 @@
+# Bulk Operations
+
+Zabbix-CLI supports performing bulk operations with the `--file` option:
+
+```bash
+zabbix-cli --file /path/to/commands.txt
+```
+
+The `--file` option takes in a file containing commands to run in bulk. Each line in the file should be a separate command. Comments are added by prepending a `#` to the line.
+
+```bash
+# /path/to/commands.txt
+# This is a comment
+show_hostgroup "Linux servers"
+create_host foobarbaz.example.com --hostgroup "Linux servers,Applications" --proxy .+ --status on --no-default-hostgroup --description "Added in bulk mode"
+show_host foobarbaz.example.com
+create_hostgroup "My new group"
+add_host_to_hostgroup foobarbaz.example.com "My new group"
+remove_host_from_hostgroup foobarbaz.example.com "My new group"
+remove_hostgroup "My new group"
+remove_host foobarbaz.example.com
+```
+
+*Example of a bulk operation file that adds a host and a host group, then removes them.*
+
+## Errors
+
+By default, all errors are fatal. If a command fails, the bulk operation is aborted. This behavior can be changed with the `app.bulk_mode` setting in the configuration file:
+
+```toml
+[app]
+bulk_mode = "strict" # strict|continue|skip
+```
+
+- `strict`: The operation will stop at the first encountered error.
+- `continue`: The operation will continue on errors and report them afterwards.
+- `skip`: Same as continue, but invalid lines in the bulk file are also skipped. Errors are completely ignored.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -225,6 +225,8 @@ Type: `str`
 
 Default: `"table"`
 
+Choices: `"table"`, `"json"`
+
 ----
 
 #### `history`
@@ -244,6 +246,16 @@ File for storing the history of commands.
 Type: `str`
 
 Default: `"<DATA_DIR>/zabbix-cli/history"`
+
+----
+
+#### `bulk_mode`
+
+Strictness of error handling in bulk operations. If `strict`, the operation will stop at the first error. If `continue`, the operation will continue after errors and report them afterwards. If `skip`, the operation will skip invalid lines in bulk file, as well as ignore all errors when executing the operation.
+
+Type: `str`
+
+Choices: `"strict"`, `"continue"`, `"skip"`
 
 ----
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,8 +100,8 @@ nav:
     - Configuration: guide/configuration.md
     - Authentication: guide/authentication.md
     - Usage: guide/usage.md
-    - Migration: guide/migration.md
     - Bulk Operations: guide/bulk.md
+    - Migration: guide/migration.md
     - Commands:
       - guide/commands/*.md
   - Plugins:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
     - Authentication: guide/authentication.md
     - Usage: guide/usage.md
     - Migration: guide/migration.md
+    - Bulk Operations: guide/bulk.md
     - Commands:
       - guide/commands/*.md
   - Plugins:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,8 @@ from typing import Iterator
 
 import pytest
 import typer
-from typer import Typer
 from typer.testing import CliRunner
+from zabbix_cli.app import StatefulApp
 from zabbix_cli.config.model import Config
 from zabbix_cli.main import app
 from zabbix_cli.pyzabbix.client import ZabbixAPI
@@ -17,7 +17,7 @@ runner = CliRunner()
 
 
 @pytest.fixture(name="app")
-def _app() -> Iterator[Typer]:
+def _app() -> Iterator[StatefulApp]:
     yield app
 
 
@@ -26,7 +26,7 @@ def app_runner():
 
 
 @pytest.fixture
-def ctx(app: Typer) -> typer.Context:
+def ctx(app: StatefulApp) -> typer.Context:
     """Create context for the main command."""
     # Use the CliRunner to invoke a command and capture the context
     obj = {}

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 import typer
+from inline_snapshot import snapshot
 from zabbix_cli.app.app import StatefulApp
 from zabbix_cli.bulk import BulkCommand
 from zabbix_cli.bulk import BulkRunner
@@ -131,66 +132,104 @@ create_user username --firstname name --lastname surname --passwd mypass # trail
 acknowledge_event 123,456,789 --message "foo message" --close
 # Command with negative flag
 show_templategroup mygroup --no-templates
+# Command with optional boolean flags
+show_host *.example.com --no-maintenance --monitored
+# Command with enum option (human-readable string)
+show_host *.example.com --active available
+# Command with enum option (API values)
+show_host *.example.com --active 0
+show_host *.example.com --active 1
+show_host *.example.com --active 2
 # we will end with a blank line
 """
     )
     b = BulkRunner(ctx, file)
     commands = b.load_command_file()
-    assert len(commands) == 6
-    assert commands[0] == BulkCommand(command="show_zabbixcli_config", line_number=2)
-    assert commands[1] == BulkCommand(
-        command="create_user",
-        kwargs={
-            "username": "username",
-            "first_name": "name",
-            "last_name": "surname",
-            "args": ["mypass", "1", "1", "86400", "1,2"],
-        },
-        line_number=4,
-    )
-    assert commands[2] == BulkCommand(
-        command="create_user",
-        kwargs={
-            "username": "username",
-            "first_name": "name",
-            "last_name": "surname",
-            "password": "mypass",
-            "role": "1",
-            "autologin": True,
-            "autologout": "86400",
-            "groups": "1,2",
-            "args": [],
-        },
-        line_number=5,
-    )
-    assert commands[3] == BulkCommand(
-        command="create_user",
-        kwargs={
-            "username": "username",
-            "first_name": "name",
-            "last_name": "surname",
-            "password": "mypass",
-            "args": [],
-        },
-        line_number=7,
-    )
-    assert commands[4] == BulkCommand(
-        command="acknowledge_event",
-        kwargs={
-            "event_ids": "123,456,789",
-            "message": "foo message",
-            "close": True,
-            "args": [],
-        },
-        line_number=9,
-    )
-    assert commands[5] == BulkCommand(
-        command="show_templategroup",
-        kwargs={
-            "templategroup": "mygroup",
-            "templates": False,
-        },
-        line_number=11,
+    assert len(commands) == snapshot(11)
+    assert commands == snapshot(
+        [
+            BulkCommand(command="show_zabbixcli_config", kwargs={}, line_number=2),
+            BulkCommand(
+                command="create_user",
+                kwargs={
+                    "username": "username",
+                    "args": ["mypass", "1", "1", "86400", "1,2"],
+                    "first_name": "name",
+                    "last_name": "surname",
+                },
+                line_number=4,
+            ),
+            BulkCommand(
+                command="create_user",
+                kwargs={
+                    "username": "username",
+                    "args": [],
+                    "first_name": "name",
+                    "last_name": "surname",
+                    "password": "mypass",
+                    "role": "1",
+                    "autologin": True,
+                    "autologout": "86400",
+                    "groups": "1,2",
+                },
+                line_number=5,
+            ),
+            BulkCommand(
+                command="create_user",
+                kwargs={
+                    "username": "username",
+                    "args": [],
+                    "first_name": "name",
+                    "last_name": "surname",
+                    "password": "mypass",
+                },
+                line_number=7,
+            ),
+            BulkCommand(
+                command="acknowledge_event",
+                kwargs={
+                    "event_ids": "123,456,789",
+                    "args": [],
+                    "message": "foo message",
+                    "close": True,
+                },
+                line_number=9,
+            ),
+            BulkCommand(
+                command="show_templategroup",
+                kwargs={"templategroup": "mygroup", "templates": False},
+                line_number=11,
+            ),
+            BulkCommand(
+                command="show_host",
+                kwargs={
+                    "hostname_or_id": "*.example.com",
+                    "maintenance": False,
+                    "monitored": True,
+                },
+                line_number=13,
+            ),
+            BulkCommand(
+                command="show_host",
+                kwargs={"hostname_or_id": "*.example.com", "active": "available"},
+                line_number=15,
+            ),
+            BulkCommand(
+                command="show_host",
+                kwargs={"hostname_or_id": "*.example.com", "active": "0"},
+                line_number=17,
+            ),
+            BulkCommand(
+                command="show_host",
+                kwargs={"hostname_or_id": "*.example.com", "active": "1"},
+                line_number=18,
+            ),
+            BulkCommand(
+                command="show_host",
+                kwargs={"hostname_or_id": "*.example.com", "active": "2"},
+                line_number=19,
+            ),
+        ]
     )
 
 

--- a/zabbix_cli/bulk.py
+++ b/zabbix_cli/bulk.py
@@ -8,15 +8,24 @@ from __future__ import annotations
 
 import logging
 import shlex
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
+from typing import Counter
 from typing import Dict
 from typing import List
+from typing import Optional
+from typing import Sequence
 from typing import Union
 
+import click
 import click.core
+import typer
 import typer.core
 from pydantic import BaseModel
 from pydantic import Field
+from typing_extensions import Self
 
 from zabbix_cli.exceptions import CommandFileError
 from zabbix_cli.utils.commands import get_command_by_name
@@ -46,136 +55,226 @@ class CommentLineError(SkippableLineError):
 
 
 KwargType = Union[str, bool, int, float, None]
+KwargsDict = Dict[str, Union[KwargType, Sequence[KwargType]]]
+
+
+@dataclass
+class ParsedOption:
+    """Represents a parsed command line option."""
+
+    name: str
+    value: Union[KwargType, Sequence[KwargType]]
+    is_multiple: bool = False
 
 
 class BulkCommand(BaseModel):
     """A command to be run in bulk."""
 
     command: str
-    kwargs: Dict[str, Union[KwargType, List[KwargType]]] = Field(default_factory=dict)
+    kwargs: Dict[
+        str,
+        Union[KwargType, Sequence[KwargType]],
+    ] = Field(default_factory=dict)
+    line_number: int
 
     @classmethod
-    def from_line(cls, line: str, ctx: typer.Context) -> BulkCommand:
+    def from_line(cls, line: str, lineno: int, ctx: typer.Context) -> Self:
         """Parse a command line into a BulkCommand."""
+        # Early returns for empty lines and comments
         line = line.strip()
         if not line:
             raise EmptyLineError("Cannot parse empty line")
         if line.startswith("#"):
             raise CommentLineError("Cannot parse comment line")
-        tokens = shlex.split(line, comments=True)
 
-        cmd_name = tokens.pop(0)
+        # Split the line into tokens, handling quotes and comments
+        tokens = shlex.split(line, comments=True)
+        if not tokens:
+            raise LineParseError("No command specified")
+
+        # Get the command and validate it exists
+        cmd_name = tokens[0]
         cmd = get_command_by_name(ctx, cmd_name)
         if not cmd.name:
             raise LineParseError(f"Invalid command {cmd_name}")
 
-        args: List[str] = []
-        kwargs: Dict[
-            str, KwargType | List[KwargType]
-        ] = {}  # TODO: support other types. ints, floats, bools
+        # Create parameter lookup tables for easier access
+        param_by_opt = {
+            opt: param
+            for param in cmd.params
+            if param.name
+            for opt in (list(param.opts) + list(param.secondary_opts))
+        }
+        positional_params = [
+            p for p in cmd.params if isinstance(p, typer.core.TyperArgument)
+        ]
 
-        next_is_kwarg = False  # next token is a value for an option
-        next_param = None  # param for next token
-        for token in tokens:
-            if token.startswith("#"):
-                break  # encountered comment, no more tokens
+        parsed_options: Dict[str, ParsedOption] = {}
+        positional_args: List[str] = []
 
-            # If we are expecting a keyword argument, set it
-            if next_is_kwarg and next_param:
-                if not next_param.name:
-                    raise LineParseError(f"Unnamed parameter {next_param}")
-                if next_param.multiple:
-                    if next_param.name not in kwargs:
-                        kwargs[next_param.name] = []
-                    kwargs[next_param.name].append(token)  # type: ignore # guaranteed to be list
-                else:
-                    kwargs[next_param.name] = token
-                next_is_kwarg = False
-                next_param = None
-            elif token.startswith("-") and len(token) > 1:
-                for param in cmd.params:
-                    if not param.name:
-                        continue
-                    if token in param.opts or token in param.secondary_opts:
-                        if param.type == click.BOOL:
-                            # We have a flag with no argument (maybe????)
-                            if param.secondary_opts and token in param.secondary_opts:
-                                kwargs[param.name] = False
-                            else:
-                                kwargs[param.name] = True
-                        else:
-                            next_is_kwarg = True
-                            next_param = param
-                        break
-                else:
+        # Parse options and arguments
+        i = 1
+        while i < len(tokens):
+            token = tokens[i]
+
+            # Handle options
+            if token.startswith("-") and len(token) > 1:
+                if token not in param_by_opt:
                     raise LineParseError(f"Invalid option {token}")
+
+                param = param_by_opt[token]
+                if not param.name:
+                    raise LineParseError(f"Unnamed parameter {param}")
+
+                # Handle boolean flags
+                if param.type == click.BOOL:
+                    value = True
+                    if param.secondary_opts and token in param.secondary_opts:
+                        value = False
+                    parsed_options[param.name] = ParsedOption(param.name, value)
+                    i += 1
+                    continue
+
+                # Handle options that take values
+                if i + 1 >= len(tokens):
+                    raise LineParseError(f"Missing value for option {token}")
+
+                value = tokens[i + 1]
+                if param.multiple:
+                    if param.name not in parsed_options:
+                        parsed_options[param.name] = ParsedOption(
+                            param.name, [], is_multiple=True
+                        )
+                    parsed_options[param.name].value.append(value)  # type: ignore
+                else:
+                    parsed_options[param.name] = ParsedOption(param.name, value)
+                i += 2
             else:
-                args.append(token)
+                positional_args.append(token)
+                i += 1
 
-        # Validate kwargs
-        # If a kwarg has no argument, it should be set to True (?)
+        # Process positional arguments
+        kwargs: KwargsDict = {}
+        remaining_args = positional_args.copy()
+
+        for param in positional_params:
+            if not param.name:
+                continue
+
+            if param.required and not remaining_args:
+                raise CommandFileError(
+                    f"Missing required positional argument {param.human_readable_name}"
+                )
+
+            if param.nargs == 1 and remaining_args:
+                kwargs[param.name] = remaining_args.pop(0)
+            elif param.nargs != 1:
+                value = (
+                    remaining_args
+                    if param.nargs == -1
+                    else remaining_args[: param.nargs]
+                )
+                kwargs[param.name] = value
+                remaining_args = remaining_args[len(value) :]
+
+        # Add parsed options to kwargs
+        for opt in parsed_options.values():
+            kwargs[opt.name] = opt.value
+
+        # Validate required options
         for param in cmd.params:
-            if isinstance(param, typer.core.TyperArgument):
-                if param.name and args:
-                    # Check if param takes a single argument
-                    if param.nargs == 1:
-                        # assume the first argument is the first positional argument (???)
-                        kwargs[param.name] = args.pop(0)
-                    # Param takes multiple arguments
-                    else:
-                        # If nargs != 1, we should have a list of arguments
-                        if param.name not in kwargs:
-                            kwargs[param.name] = []
-                        # NOTE: using temp vars to convince type checker we have a list
-                        kw = kwargs[param.name]
-                        if not isinstance(kw, list):
-                            kw = [kw]
-                        kw.extend(args)
-                        kwargs[param.name] = kw
-                        # NOTE: why? What is the purpose of resetting args here?
-                        # Should we only pop off the number of arguments we need?
-                        # And if nargs == 0, we pop of all of them?
-                        args = []
-                elif param.required:
-                    raise CommandFileError(
-                        f"Missing required positional argument {param.human_readable_name} for command {cmd.name}"
-                    )
-            elif isinstance(param, typer.core.TyperOption):
-                if param.required and param.name not in kwargs:
-                    opts = "/".join(f"{p}" for p in param.opts)
-                    raise CommandFileError(
-                        f"Missing required option {opts} for command {cmd.name}"
-                    )
+            if isinstance(param, typer.core.TyperOption) and param.required:
+                if param.name not in kwargs:
+                    opts = "/".join(str(p) for p in param.opts)
+                    raise CommandFileError(f"Missing required option {opts}")
 
-        return cls(command=cmd.name, kwargs=kwargs)
-
-    # def __str__(self) -> str:
-    #     # NOTE: flags are printed incorrectly here
-    #     return (
-    #         f"{self.command} {' '.join(f'--{k} {v}' for k, v in self.kwargs.items())}"
-    #     )
+        return cls(command=cmd.name, kwargs=kwargs, line_number=lineno)
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self}>"
 
 
+class CommandResult(Enum):
+    """Result of a command execution."""
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    SKIPPED = "skipped"
+
+
+@dataclass
+class CommandExecution:
+    """Represents the execution of a single command."""
+
+    command: BulkCommand
+    result: CommandResult
+    error: Optional[BaseException] = None
+    line_number: Optional[int] = None
+
+
+class BulkRunnerMode(Enum):
+    """Mode of operation for BulkRunner."""
+
+    STRICT = "strict"  # Stop on first error
+    CONTINUE = "continue"  # Continue on errors, report at end
+    SKIP_ERRORS = "skip_errors"  # Skip lines that can't be parsed
+
+
+class BulkResultCounter(Counter[CommandResult]):
+    pass
+
+
 class BulkRunner:
-    def __init__(self, ctx: typer.Context, file: Path) -> None:
+    def __init__(
+        self,
+        ctx: typer.Context,
+        file: Path,
+        mode: BulkRunnerMode = BulkRunnerMode.STRICT,
+    ) -> None:
         self.ctx = ctx
         self.file = file
+        self.mode = mode
+        self.executions: List[CommandExecution] = []
 
-    # TODO: some sort of permissive mode here where a command can fail?
-    def run_bulk(self) -> None:
-        """Run commands in bulk from a file where each line is a CLI command
-        with arguments and options.
+    @contextmanager
+    def _command_context(self, command: BulkCommand, line_number: Optional[int] = None):
+        """Context manager for command execution with proper error handling."""
+        try:
+            yield
+            self.executions.append(
+                CommandExecution(
+                    command, CommandResult.SUCCESS, line_number=line_number
+                )
+            )
+            logger.info("Command succeeded: %s", command)
+        except (SystemExit, typer.Exit) as e:
+            self.executions.append(
+                CommandExecution(
+                    command, CommandResult.FAILURE, error=e, line_number=line_number
+                )
+            )
+            logger.debug("Command exited: %s - %s", command, e)
+            if self.mode == BulkRunnerMode.STRICT:
+                raise CommandFileError(f"Command failed: {command}") from e
+        except Exception as e:
+            self.executions.append(
+                CommandExecution(
+                    command, CommandResult.FAILURE, error=e, line_number=line_number
+                )
+            )
+            logger.error("Command failed: %s - %s", command, e)
+            if self.mode == BulkRunnerMode.STRICT:
+                raise CommandFileError(f"Command failed: {command}") from e
 
-        Each line must succeed for the next line to be run.
-        If a line fails, the command will exit with a non-zero exit code.
+    def run_bulk(self) -> Counter[CommandResult]:
+        """Run commands in bulk from a file where each line is a CLI command.
 
+        Returns:
+            Dict[CommandResult, int]: Count of commands by result status
         Raises:
-            CommandFileError: If command file cannot be parsed or a command fails.
+            CommandFileError: If command file cannot be parsed or a command fails (in STRICT mode)
 
-        Example::
+        Example:
 
         ```bash
         $ cat /tmp/commands.txt
@@ -187,40 +286,87 @@ class BulkRunner:
 
         # Or new-form keyword arguments
         create_host test000002.example.net --hostgroup All-manual-hosts --proxy .+ --status 1
-        ```
         """
         commands = self.load_command_file()
-        for command in commands:
-            try:
-                # TODO: get the command here
-                cmd = get_command_by_name(self.ctx, command.command)
-                self.ctx.invoke(cmd, **command.kwargs)
-            except (SystemExit, typer.Exit) as e:  # others?
-                logger.debug("Bulk command %s exited: %s", command, e)
-            except Exception as e:
-                raise CommandFileError(f"Error running command {command}: {e}") from e
-            else:
-                logger.info("Bulk command %s succeeded", command)
 
-    # TODO (pederhan): future improvement: support non-strict parsing
-    # discard lines that cannot be parsed, but continue parsing the rest
+        for command in commands:
+            cmd = get_command_by_name(self.ctx, command.command)
+            with self._command_context(command, command.line_number):
+                self.ctx.invoke(cmd, **command.kwargs)
+
+        # Generate summary
+        results: Counter[CommandResult] = Counter()
+        for execution in self.executions:
+            results[execution.result] += 1
+
+        # Log summary
+        total = sum(results.values())
+        logger.info(
+            "Bulk execution complete. Total: %d, Succeeded: %d, Failed: %d, Skipped: %d",
+            total,
+            results[CommandResult.SUCCESS],
+            results[CommandResult.FAILURE],
+            results[CommandResult.SKIPPED],
+        )
+
+        # In CONTINUE mode, raise error if any commands failed
+        if self.mode == BulkRunnerMode.CONTINUE and results[CommandResult.FAILURE] > 0:
+            failed_commands = [
+                f"Line {e.line_number}: {e.command} ({e.error})"
+                for e in self.executions
+                if e.result == CommandResult.FAILURE
+            ]
+            raise CommandFileError(
+                f"{results[CommandResult.FAILURE]} commands failed:\n"
+                + "\n".join(failed_commands)
+            )
+
+        return results
 
     def load_command_file(self) -> List[BulkCommand]:
         """Parse the contents of a command file."""
-        contents = read_file(self.file)
-        lines: List[BulkCommand] = []
+        try:
+            contents = read_file(self.file)
+        except Exception as e:
+            raise CommandFileError(f"Could not read command file: {e}") from e
+
+        commands: List[BulkCommand] = []
+
         for lineno, line in enumerate(contents.splitlines(), start=1):
             try:
-                lines.append(BulkCommand.from_line(line, self.ctx))
+                command = BulkCommand.from_line(line, lineno, self.ctx)
+                commands.append(command)
             except SkippableLineError:
-                pass  # These are expected
+                self.executions.append(
+                    CommandExecution(
+                        BulkCommand(
+                            command="", kwargs={}, line_number=lineno
+                        ),  # dummy command
+                        CommandResult.SKIPPED,
+                        line_number=lineno,
+                    )
+                )
             except Exception as e:
-                raise CommandFileError(
-                    f"Unable to parse line {lineno} '{line}'. {e}"
-                ) from e
-        return lines
+                if self.mode == BulkRunnerMode.SKIP_ERRORS:
+                    logger.warning("Skipping invalid line %d: %s", lineno, e)
+                    self.executions.append(
+                        CommandExecution(
+                            BulkCommand(
+                                command=line.strip(), kwargs={}, line_number=lineno
+                            ),
+                            CommandResult.FAILURE,
+                            error=e,
+                            line_number=lineno,
+                        )
+                    )
+                else:
+                    raise CommandFileError(
+                        f"Unable to parse line {lineno} '{line}': {e}"
+                    ) from e
+
+        return commands
 
 
 def run_bulk(ctx: typer.Context, file: Path) -> None:
-    runner = BulkRunner(ctx, file)
+    runner = BulkRunner(ctx, file, mode=BulkRunnerMode.SKIP_ERRORS)
     runner.run_bulk()

--- a/zabbix_cli/config/model.py
+++ b/zabbix_cli/config/model.py
@@ -48,6 +48,7 @@ from pydantic import model_validator
 from typing_extensions import Self
 
 from zabbix_cli._v2_compat import CONFIG_PRIORITY as CONFIG_PRIORITY_LEGACY
+from zabbix_cli.bulk import BulkRunnerMode
 from zabbix_cli.config.constants import AUTH_FILE
 from zabbix_cli.config.constants import AUTH_TOKEN_FILE
 from zabbix_cli.config.constants import OutputFormat
@@ -188,6 +189,9 @@ class AppConfig(BaseModel):
     output_format: OutputFormat = OutputFormat.TABLE
     history: bool = True
     history_file: Path = DATA_DIR / "history"
+    bulk_mode: BulkRunnerMode = Field(
+        default=BulkRunnerMode.STRICT, description="Bulk mode error handling."
+    )
 
     # Legacy options
     allow_insecure_auth_file: bool = Field(

--- a/zabbix_cli/main.py
+++ b/zabbix_cli/main.py
@@ -168,7 +168,7 @@ def main_callback(
     elif input_file:
         from zabbix_cli.bulk import run_bulk
 
-        run_bulk(ctx, input_file)
+        run_bulk(ctx, input_file, state.config.app.bulk_mode)
     elif ctx.invoked_subcommand is not None:
         return  # modern alternative to `-C` option to run a single command
     else:


### PR DESCRIPTION
DISCLAIMER: I used Claude 3.5 Sonnet (new) to assist with this PR. Writing parsers is not my strong suit, I thought I'd test Claude's capabilities by making it take a look at my ugly bulk mode code. It helped turn my awful code into something a lot more readable.

----

This PR refactors the `zabbix_cli.bulk` module and adds more robust error handling and logging. It implements 3 modes (names TBD) for running bulk commands:

- Strict
- Continue
- Skip

Where Strict aborts on any errors, Continue runs through all commands and only raises an error at the end, and Skip ignores all errors. The 3 modes were Claude's ideas, and I am not sure if we actually _need_ 3 modes. It might be enough with just Strict/Continue, since there isn't much value in outright ignoring errors.