### PR TITLE
Vendor click-repl as `zabbix_cli.repl` module

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `strict`: Stop on first error.
   - `continue`: Continue on command execution error, report at the end.
   - `ignore`: Ignore all errors, including command file parsing errors.
+- REPL autocompletion for enums and paths.
 
 ## [3.1.3]
 

--- a/uv.lock
+++ b/uv.lock
@@ -129,20 +129,6 @@ wheels = [
 ]
 
 [[package]]
-name = "click-repl"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "prompt-toolkit" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/60/30/11d3f09eff5ae3627bca79563855035e8d241444520500a3c7914eae6a74/click-repl-0.2.0.tar.gz", hash = "sha256:cd12f68d745bf6151210790540b4cb064c7b13e571bc64b6957d98d120dacfd8", size = 5743 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/33/15f401400cc0cf2470aa777d225e772f83a68541495e015d2fa5c77d33d0/click_repl-0.2.0-py3-none-any.whl", hash = "sha256:94b3fbbc9406a236f176e0506524b2937e4b23b6f4c0c0b2a0a83f8a64e9194b", size = 5163 },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -446,14 +432,14 @@ wheels = [
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.47"
+version = "3.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/6d/0279b119dafc74c1220420028d490c4399b790fc1256998666e3a341879f/prompt_toolkit-3.0.47.tar.gz", hash = "sha256:1e1b29cb58080b1e69f207c893a1a7bf16d127a5c30c9d17a25a5d77792e5360", size = 425859 }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/4f/feb5e137aff82f7c7f3248267b97451da3644f6cdc218edfe549fb354127/prompt_toolkit-3.0.48.tar.gz", hash = "sha256:d6623ab0477a80df74e646bdbc93621143f5caf104206aa29294d53de1a03d90", size = 424684 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/23/22750c4b768f09386d1c3cc4337953e8936f48a888fa6dddfb669b2c9088/prompt_toolkit-3.0.47-py3-none-any.whl", hash = "sha256:0d7bfa67001d5e39d02c224b663abc33687405033a8c422d0d675a5a13361d10", size = 386411 },
+    { url = "https://files.pythonhosted.org/packages/a9/6a/fd08d94654f7e67c52ca30523a178b3f8ccc4237fce4be90d39c938a831a/prompt_toolkit-3.0.48-py3-none-any.whl", hash = "sha256:f49a827f90062e411f1ce1f854f2aedb3c23353244f8108b89283587397ac10e", size = 386595 },
 ]
 
 [[package]]
@@ -820,14 +806,14 @@ wheels = [
 
 [[package]]
 name = "zabbix-cli-uio"
-version = "3.1.1"
+version = "3.1.3"
 source = { editable = "." }
 dependencies = [
-    { name = "click-repl" },
     { name = "httpx", extra = ["socks"] },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "packaging" },
     { name = "platformdirs" },
+    { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "rich" },
     { name = "strenum" },
@@ -852,13 +838,13 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "build", marker = "extra == 'build'" },
-    { name = "click-repl", specifier = "==0.2.0" },
     { name = "freezegun", marker = "extra == 'test'" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.26.0" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'", specifier = ">=8.5.0" },
     { name = "inline-snapshot", marker = "extra == 'test'" },
     { name = "packaging", specifier = ">=22.0" },
     { name = "platformdirs", specifier = ">=2.5.4" },
+    { name = "prompt-toolkit", specifier = ">=3.0.47" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pyinstaller", marker = "extra == 'build'" },
     { name = "pytest", marker = "extra == 'test'" },

--- a/zabbix_cli/main.py
+++ b/zabbix_cli/main.py
@@ -45,15 +45,10 @@ def run_repl(ctx: typer.Context) -> None:
     from rich.console import Group
     from rich.panel import Panel
 
-    # Patch click-repl THEN import it
-    # Apply patches here to avoid impacting startup time of the CLI
-    from zabbix_cli._patches.click_repl import patch
     from zabbix_cli.output.console import console
     from zabbix_cli.output.style import green
+    from zabbix_cli.repl.repl import repl as start_repl
     from zabbix_cli.state import get_state
-
-    patch()
-    from zabbix_cli._patches.click_repl import repl as start_repl
 
     state = get_state()
 
@@ -78,7 +73,7 @@ def run_repl(ctx: typer.Context) -> None:
         state.revert_config_overrides()
 
     prompt_kwargs: Dict[str, Any] = {"pre_run": pre_run, "history": state.history}
-    start_repl(ctx, prompt_kwargs=prompt_kwargs, app=app)
+    start_repl(ctx, app, prompt_kwargs=prompt_kwargs)
 
 
 def version_callback(value: bool):
@@ -190,7 +185,6 @@ def should_skip_configuration(ctx: typer.Context) -> bool:
 
 def should_skip_login(ctx: typer.Context) -> bool:
     """Check if the command should skip logging in to the Zabbix API."""
-
     if should_skip_configuration(ctx):
         return True
     return ctx.invoked_subcommand in ["migrate_config"]

--- a/zabbix_cli/repl/__init__.py
+++ b/zabbix_cli/repl/__init__.py
@@ -1,0 +1,11 @@
+"""This module is based on click-repl (https://github.com/click-contrib/click-repl) @ f08ba39
+
+Click-repl is licensed under the MIT license and has the following copyright notices:
+    Copyright (c) 2014-2015 Markus Unterwaditzer & contributors.
+    Copyright (c) 2016-2026 Asif Saif Uddin & contributors.
+
+The module uses the original click-repl code as a basis for providing a REPL
+with autocompletion for the application. Several modifications have been made
+to adapt the code to the needs of Zabbix-CLI, as well as removing compatibility
+with Python 2 and Click < 8.0.
+"""

--- a/zabbix_cli/repl/__init__.py
+++ b/zabbix_cli/repl/__init__.py
@@ -4,8 +4,35 @@ Click-repl is licensed under the MIT license and has the following copyright not
     Copyright (c) 2014-2015 Markus Unterwaditzer & contributors.
     Copyright (c) 2016-2026 Asif Saif Uddin & contributors.
 
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+    of the Software, and to permit persons to whom the Software is furnished to do
+    so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
 The module uses the original click-repl code as a basis for providing a REPL
 with autocompletion for the application. Several modifications have been made
 to adapt the code to the needs of Zabbix-CLI, as well as removing compatibility
 with Python 2 and Click < 8.0.
+
+Most prominently, the code has been refactored to take in a Typer app when
+starting the REPL, which allows us to pass in more information about the available
+commands and options to the REPL.
+
+Furthermore, type annotations have been added to the entire vendored codebase,
+and changes have been made in order to make the code pass type checking.
+This includes removing code that adds compatibility with Click < 8.0, which
+relied a lot on duck typing and was generally not type-safe.
 """

--- a/zabbix_cli/repl/completer.py
+++ b/zabbix_cli/repl/completer.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import os
+import shlex
+from glob import iglob
+from typing import Any
+from typing import Generator
+from typing import List
+from typing import Optional
+
+import click
+from prompt_toolkit.completion import CompleteEvent
+from prompt_toolkit.completion import Completer
+from prompt_toolkit.completion import Completion
+from prompt_toolkit.document import Document
+
+__all__ = ["ClickCompleter"]
+
+IS_WINDOWS = os.name == "nt"
+
+
+AUTO_COMPLETION_PARAM = "shell_complete"
+
+
+def split_arg_string(string: str, posix: bool = True) -> List[str]:
+    """Split an argument string as with :func:`shlex.split`, but don't
+    fail if the string is incomplete. Ignores a missing closing quote or
+    incomplete escape sequence and uses the partial token as-is.
+    .. code-block:: python
+        split_arg_string("example 'my file")
+        ["example", "my file"]
+        split_arg_string("example my\\")
+        ["example", "my"]
+    :param string: String to split.
+    """
+
+    lex = shlex.shlex(string, posix=posix)
+    lex.whitespace_split = True
+    lex.commenters = ""
+    out: List[str] = []
+
+    try:
+        for token in lex:
+            out.append(token)
+    except ValueError:
+        # Raised when end-of-string is reached in an invalid state. Use
+        # the partial token as-is. The quote or escape character is in
+        # lex.state, not lex.token.
+        out.append(lex.token)
+
+    return out
+
+
+def _resolve_context(args: List[Any], ctx: click.Context) -> click.Context:
+    """Produce the context hierarchy starting with the command and
+    traversing the complete arguments. This only follows the commands,
+    it doesn't trigger input prompts or callbacks.
+
+    :param args: List of complete args before the incomplete value.
+    :param cli_ctx: `click.Context` object of the CLI group
+    """
+
+    while args:
+        command = ctx.command
+
+        if isinstance(command, click.MultiCommand):
+            if not command.chain:
+                name, cmd, args = command.resolve_command(ctx, args)
+
+                if cmd is None:
+                    return ctx
+
+                ctx = cmd.make_context(name, args, parent=ctx, resilient_parsing=True)
+                args = ctx.protected_args + ctx.args
+            else:
+                sub_ctx = ctx
+                while args:
+                    name, cmd, args = command.resolve_command(ctx, args)
+
+                    if cmd is None:
+                        return ctx
+
+                    sub_ctx = cmd.make_context(
+                        name,
+                        args,
+                        parent=ctx,
+                        allow_extra_args=True,
+                        allow_interspersed_args=False,
+                        resilient_parsing=True,
+                    )
+                    args = sub_ctx.args
+                ctx = sub_ctx
+                args = [*sub_ctx.protected_args, *sub_ctx.args]
+        else:
+            break
+
+    return ctx
+
+
+class ClickCompleter(Completer):
+    __slots__ = ("cli", "ctx", "parsed_args", "parsed_ctx", "ctx_command")
+
+    def __init__(
+        self,
+        cli: click.Group,
+        ctx: click.Context,
+        show_only_unused: bool = False,
+        shortest_only: bool = False,
+    ) -> None:
+        self.cli = cli
+        self.ctx = ctx
+        self.parsed_args = []
+        self.parsed_ctx = ctx
+        self.ctx_command = ctx.command
+        self.show_only_unused = show_only_unused
+        self.shortest_only = shortest_only
+
+    def _get_completion_from_autocompletion_functions(
+        self,
+        param: click.Parameter,
+        autocomplete_ctx: click.Context,
+        args: List[str],
+        incomplete: str,
+    ):
+        param_choices: List[Completion] = []
+        autocompletions = param.shell_complete(autocomplete_ctx, incomplete)
+        for autocomplete in autocompletions:
+            param_choices.append(Completion(str(autocomplete.value), -len(incomplete)))
+        return param_choices
+
+    def _get_completion_for_Path_types(
+        self, param: click.Parameter, args: List[str], incomplete: str
+    ) -> List[Completion]:
+        if "*" in incomplete:
+            return []
+
+        choices: List[Completion] = []
+        _incomplete = os.path.expandvars(incomplete)
+        search_pattern = _incomplete.strip("'\"\t\n\r\v ").replace("\\\\", "\\") + "*"
+        quote = ""
+
+        if " " in _incomplete:
+            for i in incomplete:
+                if i in ("'", '"'):
+                    quote = i
+                    break
+
+        for path in iglob(search_pattern):
+            if " " in path:
+                if quote:
+                    path = quote + path
+                else:
+                    if IS_WINDOWS:
+                        path = repr(path).replace("\\\\", "\\")
+            else:
+                if IS_WINDOWS:
+                    path = path.replace("\\", "\\\\")
+
+            choices.append(
+                Completion(
+                    str(path),
+                    -len(incomplete),
+                    display=str(os.path.basename(path.strip("'\""))),
+                )
+            )
+
+        return choices
+
+    def _get_completion_for_Boolean_type(self, param: click.Parameter, incomplete: str):
+        return [
+            Completion(str(k), -len(incomplete), display_meta=str("/".join(v)))
+            for k, v in {
+                "true": ("1", "true", "t", "yes", "y", "on"),
+                "false": ("0", "false", "f", "no", "n", "off"),
+            }.items()
+            if any(i.startswith(incomplete) for i in v)
+        ]
+
+    def _get_completion_from_params(
+        self,
+        autocomplete_ctx: click.Context,
+        args: List[str],
+        param: click.Parameter,
+        incomplete: str,
+    ) -> List[Completion]:
+        choices: List[Completion] = []
+        if isinstance(param.type, click.types.BoolParamType):
+            # Only suggest completion if parameter is not a flag
+            if isinstance(param, click.Option) and not param.is_flag:
+                choices.extend(self._get_completion_for_Boolean_type(param, incomplete))
+        elif isinstance(param.type, (click.Path, click.File)):
+            choices.extend(self._get_completion_for_Path_types(param, args, incomplete))
+        elif getattr(param, AUTO_COMPLETION_PARAM, None) is not None:
+            choices.extend(
+                self._get_completion_from_autocompletion_functions(
+                    param,
+                    autocomplete_ctx,
+                    args,
+                    incomplete,
+                )
+            )
+
+        return choices
+
+    def _get_completion_for_cmd_args(
+        self,
+        ctx_command: click.Command,
+        incomplete: str,
+        autocomplete_ctx: click.Context,
+        args: List[str],
+    ) -> List[Completion]:
+        choices: List[Completion] = []
+        param_called = False
+
+        for param in ctx_command.params:
+            if isinstance(param.type, click.types.UnprocessedParamType):
+                return []
+
+            elif getattr(param, "hidden", False):
+                continue
+
+            elif isinstance(param, click.Option):
+                opts = param.opts + param.secondary_opts
+                previous_args = args[: param.nargs * -1]
+                current_args = args[param.nargs * -1 :]
+
+                # Show only unused opts
+                already_present = any([opt in previous_args for opt in opts])
+                hide = self.show_only_unused and already_present and not param.multiple
+
+                # Show only shortest opt
+                if (
+                    self.shortest_only
+                    and not incomplete  # just typed a space
+                    # not selecting a value for a longer version of this option
+                    and args[-1] not in opts
+                ):
+                    opts = [min(opts, key=len)]
+
+                for option in opts:
+                    # We want to make sure if this parameter was called
+                    # If we are inside a parameter that was called, we want to show only
+                    # relevant choices
+                    if option in current_args:  # noqa: E203
+                        param_called = True
+                        break
+
+                    elif option.startswith(incomplete) and not hide:
+                        choices.append(
+                            Completion(
+                                str(option),
+                                -len(incomplete),
+                                display_meta=str(param.help or ""),
+                            )
+                        )
+
+                if param_called:
+                    choices = self._get_completion_from_params(
+                        autocomplete_ctx, args, param, incomplete
+                    )
+                    break
+
+            elif isinstance(param, click.Argument):
+                choices.extend(
+                    self._get_completion_from_params(
+                        autocomplete_ctx, args, param, incomplete
+                    )
+                )
+
+        return choices
+
+    def get_completions(
+        self, document: Document, complete_event: Optional[CompleteEvent] = None
+    ) -> Generator[Completion, Any, None]:
+        # Code analogous to click._bashcomplete.do_complete
+
+        args = split_arg_string(document.text_before_cursor, posix=False)
+
+        choices: List[Completion] = []
+        cursor_within_command = (
+            document.text_before_cursor.rstrip() == document.text_before_cursor
+        )
+
+        if document.text_before_cursor.startswith(("!", ":")):
+            return
+
+        if args and cursor_within_command:
+            # We've entered some text and no space, give completions for the
+            # current word.
+            incomplete = args.pop()
+        else:
+            # We've not entered anything, either at all or for the current
+            # command, so give all relevant completions for this context.
+            incomplete = ""
+
+        if self.parsed_args != args:
+            self.parsed_args = args
+            try:
+                self.parsed_ctx = _resolve_context(args, self.ctx)
+            except Exception:
+                return  # autocompletion for nonexistent cmd can throw here
+            self.ctx_command = self.parsed_ctx.command
+
+        if getattr(self.ctx_command, "hidden", False):
+            return
+
+        try:
+            choices.extend(
+                self._get_completion_for_cmd_args(
+                    self.ctx_command, incomplete, self.parsed_ctx, args
+                )
+            )
+
+            if isinstance(self.ctx_command, click.MultiCommand):
+                incomplete_lower = incomplete.lower()
+
+                for name in self.ctx_command.list_commands(self.parsed_ctx):
+                    command = self.ctx_command.get_command(self.parsed_ctx, name)
+                    if getattr(command, "hidden", False):
+                        continue
+
+                    elif name.lower().startswith(incomplete_lower):
+                        choices.append(
+                            Completion(
+                                str(name),
+                                -len(incomplete),
+                                display_meta=getattr(command, "short_help", ""),
+                            )
+                        )
+
+        except Exception as e:
+            click.echo(f"{type(e).__name__}: {str(e)}")
+
+        # If we are inside a parameter that was called, we want to show only
+        # relevant choices
+        # if param_called:
+        #     choices = param_choices
+
+        yield from choices

--- a/zabbix_cli/repl/repl.py
+++ b/zabbix_cli/repl/repl.py
@@ -106,67 +106,6 @@ _register_internal_command(
 )
 
 
-# class ClickCompleter(Completer):
-#     def __init__(self, cli: click.Group) -> None:
-#         self.cli = cli
-
-#     def get_completions(
-#         self, document: Document, complete_event: CompleteEvent
-#     ) -> Generator[Any, Any, None]:
-#         # Code analogous to click._bashcomplete.do_complete
-
-#         try:
-#             args = shlex.split(document.text_before_cursor)
-#         except ValueError:
-#             # Invalid command, perhaps caused by missing closing quotation.
-#             return
-
-#         cursor_within_command = (
-#             document.text_before_cursor.rstrip() == document.text_before_cursor
-#         )
-
-#         if args and cursor_within_command:
-#             # We've entered some text and no space, give completions for the
-#             # current word.
-#             incomplete = args.pop()
-#         else:
-#             # We've not entered anything, either at all or for the current
-#             # command, so give all relevant completions for this context.
-#             incomplete = ""
-#         # Resolve context based on click version
-#         ctx = click.shell_completion._resolve_context(self.cli, {}, "", args)  # pyright: ignore[reportPrivateUsage]
-
-#         choices: List[Completion] = []
-#         for param in ctx.command.params:
-#             if isinstance(param, click.Option):
-#                 for options in (param.opts, param.secondary_opts):
-#                     for o in options:
-#                         choices.append(
-#                             Completion(
-#                                 str(o), -len(incomplete), display_meta=param.help
-#                             )
-#                         )
-#             elif isinstance(param, click.Argument):
-#                 if isinstance(param.type, click.Choice):
-#                     for choice in param.type.choices:
-#                         choices.append(Completion(str(choice), -len(incomplete)))
-
-#         if isinstance(ctx.command, click.MultiCommand):
-#             for name in ctx.command.list_commands(ctx):
-#                 command = ctx.command.get_command(ctx, name)
-#                 choices.append(
-#                     Completion(
-#                         str(name),
-#                         -len(incomplete),
-#                         display_meta=getattr(command, "short_help"),
-#                     )
-#                 )
-
-#         for item in choices:
-#             if item.text.startswith(incomplete):
-#                 yield item
-
-
 def bootstrap_prompt(
     prompt_kwargs: Optional[Dict[str, Any]],
     group: click.Group,

--- a/zabbix_cli/repl/repl.py
+++ b/zabbix_cli/repl/repl.py
@@ -1,0 +1,341 @@
+"""Patches for click_repl package."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import sys
+from collections import defaultdict
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import DefaultDict
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import NamedTuple
+from typing import NoReturn
+from typing import Optional
+
+import click
+import click.parser
+import click.shell_completion
+from click.exceptions import Exit as ClickExit
+from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.shortcuts import prompt
+
+from zabbix_cli.exceptions import handle_exception
+from zabbix_cli.output.console import err_console
+from zabbix_cli.repl.completer import ClickCompleter
+
+if TYPE_CHECKING:
+    from click.core import Context
+
+    from zabbix_cli.app import StatefulApp
+
+
+class InternalCommandException(Exception):
+    pass
+
+
+class ExitReplException(InternalCommandException):
+    pass
+
+
+CommandCallable = Callable[..., Any]
+"""Callable for internal commands."""
+
+
+class InternalCommand(NamedTuple):
+    command: CommandCallable
+    description: str
+
+
+_internal_commands: Dict[str, InternalCommand] = dict()
+
+
+def _register_internal_command(
+    names: Iterable[str], target: CommandCallable, description: str
+):
+    if isinstance(names, str):
+        names = [names]
+
+    for name in names:
+        _internal_commands[name] = InternalCommand(target, description)
+
+
+def _get_registered_target(
+    name: str, default: Optional[CommandCallable] = None
+) -> Optional[CommandCallable]:
+    target_info = _internal_commands.get(name)
+    if target_info:
+        return target_info[0]
+    return default
+
+
+def _exit_internal() -> NoReturn:
+    raise ExitReplException()
+
+
+def _help_internal() -> str:
+    formatter = click.HelpFormatter()
+    formatter.write_heading("REPL help")
+    formatter.indent()
+    with formatter.section("External Commands"):
+        formatter.write_text('prefix external commands with "!"')
+    with formatter.section("Internal Commands"):
+        formatter.write_text('prefix internal commands with ":"')
+        info_table: DefaultDict[str, List[str]] = defaultdict(list)
+        for mnemonic, target_info in _internal_commands.items():
+            info_table[target_info[1]].append(mnemonic)
+        formatter.write_dl(
+            [
+                (
+                    ", ".join(f":{mnemonic}" for mnemonic in sorted(mnemonics)),
+                    description,
+                )
+                for description, mnemonics in info_table.items()
+            ]
+        )
+    return formatter.getvalue()
+
+
+_register_internal_command(["q", "quit", "exit"], _exit_internal, "exits the repl")
+_register_internal_command(
+    ["?", "h", "help"], _help_internal, "displays general help information"
+)
+
+
+# class ClickCompleter(Completer):
+#     def __init__(self, cli: click.Group) -> None:
+#         self.cli = cli
+
+#     def get_completions(
+#         self, document: Document, complete_event: CompleteEvent
+#     ) -> Generator[Any, Any, None]:
+#         # Code analogous to click._bashcomplete.do_complete
+
+#         try:
+#             args = shlex.split(document.text_before_cursor)
+#         except ValueError:
+#             # Invalid command, perhaps caused by missing closing quotation.
+#             return
+
+#         cursor_within_command = (
+#             document.text_before_cursor.rstrip() == document.text_before_cursor
+#         )
+
+#         if args and cursor_within_command:
+#             # We've entered some text and no space, give completions for the
+#             # current word.
+#             incomplete = args.pop()
+#         else:
+#             # We've not entered anything, either at all or for the current
+#             # command, so give all relevant completions for this context.
+#             incomplete = ""
+#         # Resolve context based on click version
+#         ctx = click.shell_completion._resolve_context(self.cli, {}, "", args)  # pyright: ignore[reportPrivateUsage]
+
+#         choices: List[Completion] = []
+#         for param in ctx.command.params:
+#             if isinstance(param, click.Option):
+#                 for options in (param.opts, param.secondary_opts):
+#                     for o in options:
+#                         choices.append(
+#                             Completion(
+#                                 str(o), -len(incomplete), display_meta=param.help
+#                             )
+#                         )
+#             elif isinstance(param, click.Argument):
+#                 if isinstance(param.type, click.Choice):
+#                     for choice in param.type.choices:
+#                         choices.append(Completion(str(choice), -len(incomplete)))
+
+#         if isinstance(ctx.command, click.MultiCommand):
+#             for name in ctx.command.list_commands(ctx):
+#                 command = ctx.command.get_command(ctx, name)
+#                 choices.append(
+#                     Completion(
+#                         str(name),
+#                         -len(incomplete),
+#                         display_meta=getattr(command, "short_help"),
+#                     )
+#                 )
+
+#         for item in choices:
+#             if item.text.startswith(incomplete):
+#                 yield item
+
+
+def bootstrap_prompt(
+    prompt_kwargs: Optional[Dict[str, Any]],
+    group: click.Group,
+    ctx: click.Context,
+    show_only_unused: bool = False,
+    shortest_only: bool = False,
+) -> Dict[str, Any]:
+    """
+    Bootstrap prompt_toolkit kwargs or use user defined values.
+
+    :param prompt_kwargs: The user specified prompt kwargs.
+    """
+    prompt_kwargs = prompt_kwargs or {}
+
+    defaults = {
+        "history": InMemoryHistory(),
+        "completer": ClickCompleter(
+            group, ctx, show_only_unused=show_only_unused, shortest_only=shortest_only
+        ),
+        "message": "> ",
+    }
+
+    for key in defaults:
+        default_value = defaults[key]
+        if key not in prompt_kwargs:
+            prompt_kwargs[key] = default_value
+
+    return prompt_kwargs
+
+
+def register_repl(group: click.Group, name: str = "repl"):
+    """Register :func:`repl()` as sub-command *name* of *group*."""
+    group.command(name=name)(click.pass_context(repl))
+
+
+def exit() -> None:
+    """Exit the repl"""
+    _exit_internal()
+
+
+def dispatch_repl_commands(command: str) -> bool:
+    """Execute system commands entered in the repl.
+
+    System commands are all commands starting with "!".
+
+    """
+    if command.startswith("!") and len(command) > 1:
+        os.system(command[1:])
+        return True
+
+    return False
+
+
+def handle_internal_commands(command: str) -> Any:
+    """Run repl-internal commands.
+
+    Repl-internal commands are all commands starting with ":".
+
+    """
+    if command.startswith(":"):
+        target = _get_registered_target(command[1:], default=None)
+        if target:
+            return target()
+
+
+def repl(  # noqa: C901
+    old_ctx: Context,
+    app: StatefulApp,
+    prompt_kwargs: Optional[Dict[str, Any]] = None,
+    allow_system_commands: bool = True,
+    allow_internal_commands: bool = True,
+) -> None:
+    """Start an interactive shell. All subcommands are available in it.
+
+    :param old_ctx: The current Click context.
+    :param prompt_kwargs: Parameters passed to
+        :py:func:`prompt_toolkit.shortcuts.prompt`.
+
+    If stdin is not a TTY, no prompt will be printed, but only commands read
+    from stdin.
+    """
+    # parent should be available, but we're not going to bother if not
+    group_ctx = old_ctx.parent or old_ctx
+    group = group_ctx.command
+    isatty = sys.stdin.isatty()
+
+    if not isinstance(group, click.Group):
+        raise RuntimeError("REPL must be started from a Typer or Click group.")
+    available_commands = group.commands
+
+    # Delete the REPL command from those available
+    repl_command_name = old_ctx.command.name
+    if repl_command_name:
+        available_commands.pop(repl_command_name, None)
+
+    # Remove hidden commands
+    available_commands = {
+        cmd_name: cmd_obj
+        for cmd_name, cmd_obj in available_commands.items()
+        if not cmd_obj.hidden
+    }
+
+    group.commands = available_commands
+    prompt_kwargs = bootstrap_prompt(prompt_kwargs, group, group_ctx)
+
+    if isatty:
+
+        def get_command() -> str:
+            return prompt(**prompt_kwargs)
+
+    else:
+        get_command = sys.stdin.readline
+
+    while True:
+        try:
+            command = get_command()
+        except KeyboardInterrupt:
+            continue
+        except EOFError:
+            break
+
+        if not command:
+            if isatty:
+                continue
+            else:
+                break
+
+        if allow_system_commands and dispatch_repl_commands(command):
+            continue
+
+        if allow_internal_commands:
+            try:
+                result = handle_internal_commands(command)
+                if isinstance(result, str):
+                    click.echo(result)
+                    continue
+            except ExitReplException:
+                break
+
+        try:
+            args = shlex.split(command)
+        except ValueError as e:
+            click.echo(f"{type(e).__name__}: {e}")
+            continue
+
+        try:
+            if app:
+                group = app.as_click_group()
+            with group.make_context(None, args, parent=group_ctx) as ctx:
+                group.invoke(ctx)
+                ctx.exit()
+        except click.ClickException as e:
+            e.show()
+        except (ClickExit, SystemExit):
+            pass
+        except ExitReplException:
+            break
+        except Exception as e:
+            try:
+                # Pass exception to the exception handler
+                # which handles printing and logging the exception
+                # The exception handler also calls sys.exit() (used in non-interactive mode)
+                # so we need to catch it and ignore it.
+                handle_exception(e)
+            except SystemExit:
+                pass
+        except KeyboardInterrupt:
+            # User likely pressed Ctrl+C during a prompt or when a spinner
+            # was active. Ensure message is printed on a new line.
+            # TODO: determine if last char in terminal was newline somehow! Can we?
+            err_console.print("\n[red]Aborted.[/]")
+            pass


### PR DESCRIPTION
This PR vendors parts of the [click-contrib/click-repl](https://github.com/click-contrib/click-repl) module, and adapts it to the needs of Zabbix-CLI. Attributions and license notices are made in `zabbix_cli.repl.__init__`.