### PR TITLE
Fix usermacro host filter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Screen flickering on application startup when not authenticating via username and password prompt.
+- `define_host_usermacro` not working as expected when using a macro name that already exists elsewhere.
 
 ## [3.1.3]
 

--- a/zabbix_cli/pyzabbix/client.py
+++ b/zabbix_cli/pyzabbix/client.py
@@ -1463,7 +1463,7 @@ class ZabbixAPI:
         params: ParamsType = {"output": "extend"}
 
         if host:
-            add_param(params, "search", "hostids", host.hostid)
+            params["hostids"] = host.hostid
 
         if macro_name:
             add_param(params, "search", "macro", macro_name)


### PR DESCRIPTION
When searching for a macro, we added host IDs under the `search.hostids` parameter instead of the `hostids` parameter. This lead to returning a macro from the first host with the given macro name instead of limiting the search to only the given host.