### PR TITLE
Prompt for Zabbix URL if missing from config

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Custom auth (token) file paths in config now take precedence over the default path if both exist.
+- Application now prompts for Zabbix API URL if missing from config.
 
 ## [3.2.0]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,6 @@ from typing import Union
 
 import pytest
 from inline_snapshot import snapshot
-from pydantic import ValidationError
 from zabbix_cli.config.model import Config
 from zabbix_cli.config.model import PluginConfig
 from zabbix_cli.config.model import PluginsConfig
@@ -18,11 +17,8 @@ from zabbix_cli.exceptions import PluginConfigTypeError
 
 
 def test_config_default() -> None:
-    """Assert that the config by default only requires a URL."""
-    with pytest.raises(ValidationError) as excinfo:
-        Config()
-    assert "1 validation error" in str(excinfo.value)
-    assert "url" in str(excinfo.value)
+    """Assert that the config can be instantiated with no arguments."""
+    assert Config()
 
 
 def test_sample_config() -> None:

--- a/zabbix_cli/config/model.py
+++ b/zabbix_cli/config/model.py
@@ -86,7 +86,7 @@ class BaseModel(PydanticBaseModel):
 
 class APIConfig(BaseModel):
     url: str = Field(
-        default=...,
+        default="",
         # Changed in V3: zabbix_api_url -> url
         validation_alias=AliasChoices("url", "zabbix_api_url"),
     )

--- a/zabbix_cli/config/utils.py
+++ b/zabbix_cli/config/utils.py
@@ -96,7 +96,6 @@ def init_config(
     from zabbix_cli.dirs import init_directories
     from zabbix_cli.output.console import info
     from zabbix_cli.output.prompts import str_prompt
-    from zabbix_cli.pyzabbix.client import ZabbixAPI
 
     # Create required directories
     init_directories()
@@ -120,8 +119,7 @@ def init_config(
         config.api.username = username
 
     if login:
-        client = ZabbixAPI.from_config(config)
-        auth.login(client, config)
+        auth.login(config)
 
     config.dump_to_file(config_file)
     info(f"Configuration file created: {config_file}")

--- a/zabbix_cli/pyzabbix/client.py
+++ b/zabbix_cli/pyzabbix/client.py
@@ -246,7 +246,7 @@ class ZabbixAPI:
         self.id = 0
 
         server, _, _ = server.partition(RPC_ENDPOINT)
-        self.url = f"{server}/api_jsonrpc.php"
+        self.url = self._get_url(server)
         logger.info("JSON-RPC Server Endpoint: %s", self.url)
 
         # Cache
@@ -254,6 +254,15 @@ class ZabbixAPI:
 
         # Attributes for properties
         self._version: Optional[Version] = None
+
+    def _get_url(self, server: str) -> str:
+        """Format a URL for the Zabbix API."""
+        return f"{server}/api_jsonrpc.php"
+
+    def set_url(self, server: str) -> str:
+        """Set a new URL for the client."""
+        self.url = self._get_url(server)
+        return self.url
 
     @classmethod
     def from_config(cls, config: Config) -> ZabbixAPI:

--- a/zabbix_cli/state.py
+++ b/zabbix_cli/state.py
@@ -220,11 +220,8 @@ class State:
         so that each model is aware of which version its data is from."""
         from zabbix_cli import auth
         from zabbix_cli.models import TableRenderable
-        from zabbix_cli.pyzabbix.client import ZabbixAPI
 
-        self.client = ZabbixAPI.from_config(self.config)
-
-        auth.login(self.client, self.config)
+        self.client = auth.login(self.config)
         TableRenderable.zabbix_version = self.client.version
         TableRenderable.legacy_json_format = self.config.app.legacy_json_format
 


### PR DESCRIPTION
This PR adds prompting for URL if missing. Also refactors `ZabbixAPI` client setup by moving it into the `Authenticator` class, which makes more sense when calling `auth.login` from different places, all of which might not have a client instance ready. Furthermore, it allows us to control the instantiation of the client from within the login flow, granting us more control over the configuration of the client there.