### PR TITLE
Add `app.output` table, check deprecated options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,10 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New configuration file table `[app.output]`:
-  - `format`: Default output format for commands. Defaults to `table`.
+  - `format`: Default output format for commands. Defaults to `"table"`.
   - `color`: Enable or disable color output. Defaults to `true`.
   - `paging`: Enable or disable paging of output. Defaults to `false`.
-  - `theme`: Color theme for output. Defaults to `default`.
+  - `theme`: Color theme for output. Defaults to `"default"`.
 - Application now automatically assigns deprecated config options to their new equivalents internally.
 - New command `update_config` to update an outdated configuration file with new options, as well as any currently applied overrides.
 - `show_config --secrets <hide|mask|plain>` option for controlling the display mode of sensitive information in the configuration file. Defaults to `mask`.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,10 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New configuration file table `[app.output]`:
+  - `format`: Default output format for commands. Defaults to `table`.
+  - `color`: Enable or disable color output. Defaults to `true`.
+  - `paging`: Enable or disable paging of output. Defaults to `false`.
+  - `theme`: Color theme for output. Defaults to `default`.
+- Application now automatically assigns deprecated config options to their new equivalents internally.
+- New command `update_config` to update an outdated configuration file with new options, as well as any currently applied overrides.
+- `show_config --secrets <hide|mask|plain>` option for controlling the display mode of sensitive information in the configuration file. Defaults to `mask`.
+
 ### Changed
 
 - Custom auth (token) file paths in config now take precedence over the default path if both exist.
 - Application now prompts for Zabbix API URL if missing from config.
+- Default logging configuration is performed before loading the configuration file. Ensures a default logging configuration is always present.
+
+### Deprecated
+
+- Config options moved to `[app.output]` table:
+  - `app.use_colors`
+  - `app.use_paging`
+  - `app.output_format`
 
 ## [3.2.0]
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom auth (token) file paths in config now take precedence over the default path if both exist.
 - Application now prompts for Zabbix API URL if missing from config.
 - Default logging configuration is performed before loading the configuration file. Ensures a default logging configuration is always present.
+- Authentication method + source is now logged on successful authentication.
+- No longer attempts to add a user to the logging context when logging in with an auth token.
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ zabbix-cli --format json show_hosts
 > --format json show_hosts
 ```
 
-Or by setting the `app.output_format` parameter in the config file:
+Or by setting the `app.output.format` option in the config file:
 
 ```toml
-[app]
-output_format = "json"
+[app.output]
+format = "json"
 ```
 
 ### Table

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -4,7 +4,7 @@ The application is configured with a TOML file. The default location is platform
 
 {% include ".includes/config-locations.md" %}
 
-## Create a configuration file
+## Create a config
 
 Before using the application, a configuration file must be created. This can be done with the `init` command:
 
@@ -26,7 +26,7 @@ To overwrite an existing configuration file, use the `--overwrite` option:
 zabbix-cli init --overwrite
 ```
 
-## Open configuration directory
+## Config directory
 
 The default configuration directory can be opened in the system's file manager with the `open` command:
 
@@ -40,7 +40,7 @@ To print the path instead of opening it, use the `--path` option:
 zabbix-cli open config --path
 ```
 
-## Show configuration file contents
+## Show config
 
 The contents of the current configuration file can be displayed with `show_config`:
 
@@ -48,7 +48,7 @@ The contents of the current configuration file can be displayed with `show_confi
 zabbix-cli show_config
 ```
 
-### Create a sample config
+## Sample config
 
 A sample configuration file can be printed to the terminal with the `sample_config` command. This can be redirected to a file to create a configuration file in an arbitrary location:
 
@@ -62,22 +62,22 @@ A more convoluted way of creating a default config file in the default location 
 zabbix-cli sample_config > "$(zabbix-cli open --path config)/zabbix-cli.toml"
 ```
 
-## Sample configuration file
+The created config looks like this:
 
 ```toml
 {% include "data/sample_config.toml" %}
 ```
 
-## Configuration options
+## Options
 
-<!-- TODO: Automatically generate this from pydantic models using field name, aliases and field help.
+<!-- TODO: Automatically generate this from pydantic models using field name, aliases and field descriptions.
 
-           To do this, we need to add Field() for every field in the model, and also ensure they have help= set. Possibly also add examples.
+To do this, we need to add Field() for every field in the model, and also ensure they have description= set. Possibly also add examples.
  -->
 
 === "`api`"
 
-    The `api` section configures the Zabbix API connection.
+    The `api` section configures the application's Zabbix API connection.
 
     ```toml
     [api]
@@ -103,7 +103,7 @@ zabbix-cli sample_config > "$(zabbix-cli open --path config)/zabbix-cli.toml"
 
     #### `username`
 
-    Username for the Zabbix API.
+    Username for Zabbix API authentication. Can be used  in combination with `password`, or to provide a default username for the login prompt.
 
     Type: `str`
 
@@ -132,7 +132,7 @@ zabbix-cli sample_config > "$(zabbix-cli open --path config)/zabbix-cli.toml"
 
     #### `auth_token`
 
-    Session token or API token to use for authentication. If provided, `username` and `password` are ignored.
+    Session token or API token to use for authentication. Takes precedence over `username` and `password` if set.
 
     Type: `str`
 
@@ -457,7 +457,7 @@ zabbix-cli sample_config > "$(zabbix-cli open --path config)/zabbix-cli.toml"
 
     ```toml
     [app.output]
-    color = false
+    color = true
     ```
 
     ----

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -166,12 +166,8 @@ zabbix-cli sample_config > "$(zabbix-cli open --path config)/zabbix-cli.toml"
     default_hostgroups = [
         "All-hosts",
     ]
-    default_admin_usergroups = [
-        "Zabbix-root",
-    ]
-    default_create_user_usergroups = [
-        "All-users",
-    ]
+    default_admin_usergroups = []
+    default_create_user_usergroups = []
     default_notification_users_usergroups = [
         "All-notification-users",
     ]
@@ -216,7 +212,7 @@ zabbix-cli sample_config > "$(zabbix-cli open --path config)/zabbix-cli.toml"
 
     ```toml
     [app]
-    default_admin_usergroups = []
+    default_admin_usergroups = ["All-admins"]
     ```
 
     ----
@@ -232,7 +228,7 @@ zabbix-cli sample_config > "$(zabbix-cli open --path config)/zabbix-cli.toml"
 
     ```toml
     [app]
-    default_create_user_usergroups = []
+    default_create_user_usergroups = ["All-users"]
     ```
 
     ----

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -6,22 +6,24 @@ The application is configured with a TOML file. The default location is platform
 
 ## Create a configuration file
 
-Before using the application, a configuration file must be created. This can be done with the `zabbix-cli-init` command:
+Before using the application, a configuration file must be created. This can be done with the `init` command:
 
 ```
-zabbix-cli-init
+zabbix-cli init
 ```
 
-The application will print the location of the created config file:
-
-```
-! Configuration file created: /Users/pederhan/Library/Application Support/zabbix-cli/zabbix-cli.toml
-```
+The application will print the location of the created configuration file.
 
 To bootstrap the config with a URL and username, use the options `--url` and `--user`:
 
 ```
 zabbix-cli-init --url https://zabbix.example.com --user Admin
+```
+
+To overwrite an existing configuration file, use the `--overwrite` option:
+
+```
+zabbix-cli init --overwrite
 ```
 
 ## Open configuration directory
@@ -73,240 +75,463 @@ zabbix-cli sample_config > "$(zabbix-cli open --path config)/zabbix-cli.toml"
            To do this, we need to add Field() for every field in the model, and also ensure they have help= set. Possibly also add examples.
  -->
 
-Required fields are marked with a `*`.
+=== "`api`"
 
-----
+    The `api` section configures the Zabbix API connection.
 
-### `api`
+    ```toml
+    [api]
+    url = "https://zabbix.example.com"
+    username = "Admin"
+    password = ""
+    auth_token = ""
+    verify_ssl = true
+    ```
 
-The `api` section contains the configuration for the Zabbix API.
+    #### `url`
 
-----
+    URL of the Zabbix API host. Should not include the `/api_jsonrpc.php` path.
 
-#### `url` \*
+    Type: `str`
 
-URL of the Zabbix API host. Should not include the `/api_jsonrpc.php` path.
+    ```toml
+    [api]
+    url = "https://zabbix.example.com"
+    ```
 
-Type: `str`
+    ----
 
-----
+    #### `username`
 
-#### `username`
+    Username for the Zabbix API.
 
-Username for the Zabbix API.
+    Type: `str`
 
-Type: `str`
+    Default: `Admin`
 
-Default: `Admin`
+    ```toml
+    [api]
+    username = "Admin"
+    ```
 
-----
+    ----
 
-#### `verify_ssl`
+    #### `password`
 
-Whether to verify SSL certificates.
+    Password to use in combination with a username.
 
-Type: `bool`
+    Type: `str`
 
-Default: `true`
+    ```toml
+    [api]
+    password = "password123"
+    ```
 
-----
 
-### `app`
+    ----
 
-The `app` section contains the configuration for the application, such as default values for certain commands, output and exports.
+    #### `auth_token`
 
-----
+    Session token or API token to use for authentication. If provided, `username` and `password` are ignored.
 
-#### `default_hostgroups`
+    Type: `str`
 
-Default host groups to assign to hosts created with `create_host`. Hosts are always added to these groups unless `--no-default-hostgroup` is provided.
+    ```toml
+    [api]
+    auth_token = "API_TOKEN_123"
+    ```
 
-Type: `List[str]`
+    ----
 
-Default: `["All-hosts"]`
+    #### `verify_ssl`
 
-----
+    Whether to verify SSL certificates.
 
-#### `default_admin_usergroups`
+    Type: `bool`
 
-Default user groups to give read/write permissions to groups created with `create_hostgroup` and `create_templategroup` when `--rw-groups` option is not provided.
+    Default: `true`
 
-Type: `List[str]`
+    ```toml
+    [api]
+    verify_ssl = true
+    ```
 
-Default: `[]`
+=== "`app`"
 
-----
+    The `app` section configures general application settings, such as defaults for Zabbix host and group creation, export configuration, and more.
 
-#### `default_create_user_usergroups`
 
-Default user groups to add users created with `create_user` to when `--usergroups` is not provided.
+    ```toml
+    [app]
+    default_hostgroups = [
+        "All-hosts",
+    ]
+    default_admin_usergroups = [
+        "Zabbix-root",
+    ]
+    default_create_user_usergroups = [
+        "All-users",
+    ]
+    default_notification_users_usergroups = [
+        "All-notification-users",
+    ]
+    export_directory = "/path/to/exports"
+    export_format = "json"
+    export_timestamps = true
+    use_auth_token_file = true
+    auth_token_file = "/path/to/auth_token_file"
+    auth_file = "/path/to/auth_token_file"
+    history = true
+    history_file = "/path/to/history_file.history"
+    bulk_mode = "strict"
+    allow_insecure_auth_file = true
+    legacy_json_format = false
+    ```
 
-Type: `List[str]`
+    ----
 
-Default: `[]`
+    #### `default_hostgroups`
 
-----
+    Default host groups to assign to hosts created with `create_host`. Hosts are always added to these groups unless `--no-default-hostgroup` is provided.
 
-#### `default_notification_users_usergroups`
+    Type: `List[str]`
 
-Default user groups to add notification users created with `create_notification_user` to when `--usergroups` is not provided.
+    Default: `["All-hosts"]`
 
-Type: `List[str]`
 
-Default: `["All-notification-users"]`
+    ```toml
+    [app]
+    default_hostgroups = ["All-hosts"]
+    ```
 
-----
+    ----
 
-#### `export_directory`
+    #### `default_admin_usergroups`
 
-Directory for exports.
+    Default user groups to give read/write permissions to groups created with `create_hostgroup` and `create_templategroup` when `--rw-groups` option is not provided.
 
-Type: `str`
+    Type: `List[str]`
 
-Default: `"<DATA_DIR>/zabbix-cli/exports"`
+    Default: `[]`
 
-----
+    ```toml
+    [app]
+    default_admin_usergroups = []
+    ```
 
-#### `export_format`
+    ----
 
-Format for exports.
+    #### `default_create_user_usergroups`
 
-Type: `str`
+    Default user groups to add users created with `create_user` to when `--usergroups` is not provided.
 
-Default: `"json"`
+    Type: `List[str]`
 
-----
+    Default: `[]`
 
-#### `export_timestamps`
 
-Whether to include timestamps in export filenames.
+    ```toml
+    [app]
+    default_create_user_usergroups = []
+    ```
 
-Type: `bool`
+    ----
 
-Default: `false`
+    #### `default_notification_users_usergroups`
 
-----
+    Default user groups to add notification users created with `create_notification_user` to when `--usergroups` is not provided.
 
-#### `use_colors`
+    Type: `List[str]`
 
-Whether to use colors in the output.
+    Default: `["All-notification-users"]`
 
-Type: `bool`
+    ```toml
+    [app]
+    default_create_user_usergroups = ["All-notification-users"]
+    ```
 
-Default: `true`
+    ----
 
-----
+    #### `export_directory`
 
-#### `use_auth_token_file`
+    Directory for exports.
 
-Whether to use an auth token file.
+    Type: `str`
 
-Type: `bool`
+    Default: `"<DATA_DIR>/zabbix-cli/exports"`
 
-Default: `true`
+    ```toml
+    [app]
+    default_create_user_usergroups = "/path/to/exports"
+    ```
 
-----
 
-#### `use_paging`
+    ----
 
-Whether to use paging in the output.
+    #### `export_format`
 
-Type: `bool`
+    Format for exports.
 
-Default: `false`
+    Type: `str`
 
-----
+    Default: `"json"`
 
-#### `output_format`
+    ```toml
+    [app]
+    export_format = "json"
+    ```
 
-Format for the output.
 
-Type: `str`
+    ----
 
-Default: `"table"`
+    #### `export_timestamps`
 
-Choices: `"table"`, `"json"`
+    Whether to include timestamps in export filenames.
 
-----
+    Type: `bool`
 
-#### `history`
+    Default: `false`
 
-Whether to keep a history of commands.
+    ```toml
+    [app]
+    export_timestamps = false
+    ```
 
-Type: `bool`
+    ----
 
-Default: `true`
+    #### `use_auth_token_file`
 
-----
+    Whether to use an auth token file to save session token once authenticated. Allows for reusing the token in subsequent sessions.
 
-#### `history_file`
+    Type: `bool`
 
-File for storing the history of commands.
+    Default: `true`
 
-Type: `str`
+    ```toml
+    [app]
+    use_auth_token_file = true
+    ```
 
-Default: `"<DATA_DIR>/zabbix-cli/history"`
+    ----
 
-----
+    #### `auth_token_file`
 
-#### `bulk_mode`
+    Paht to the auth token file.
 
-Strictness of error handling in bulk operations. If `strict`, the operation will stop at the first error. If `continue`, the operation will continue after errors and report them afterwards. If `skip`, the operation will skip invalid lines in bulk file, as well as ignore all errors when executing the operation.
+    Type: `str`
 
-Type: `str`
+    Default: `"<DATA_DIR>/zabbix-cli/.zabbix-cli_auth_token"`
 
-Choices: `"strict"`, `"continue"`, `"skip"`
+    ```toml
+    [app]
+    auth_token_file = "/path/to/auth_token_file"
+    ```
 
-----
+    ----
 
-#### `allow_insecure_auth_file`
+    #### `auth_file`
 
-Whether to allow insecure auth files.
+    Paht to a file containing username and password in the format `username:password`. Alternative to specifying `username` and `password` in the configuration file.
 
-Type: `bool`
+    Type: `str`
 
-Default: `true`
+    Default: `"<DATA_DIR>/zabbix-cli/.zabbix-cli_auth"`
 
-----
+    ```toml
+    [app]
+    auth_token = "/path/to/auth_file"
+    ```
 
-#### `legacy_json_format`
+    ----
 
-Whether to use the legacy JSON format (pre-Zabbix CLI 3.0), where the output is a JSON mapping with numeric string keys for each result. See the [migration guide](./migration.md) for more information.
+    #### `history`
 
-Type: `bool`
+    Whether to keep a history of commands.
 
-Default: `false`
+    Type: `bool`
 
-### `logging`
+    Default: `true`
 
-The `logging` section contains the configuration for logging.
+    ```toml
+    [app]
+    history = true
+    ```
 
-----
+    ----
 
-#### `enabled`
+    #### `history_file`
 
-Whether logging is enabled.
+    File for storing the history of commands.
 
-Type: `bool`
+    Type: `str`
 
-Default: `true`
+    Default: `"<DATA_DIR>/zabbix-cli/history"`
 
-----
 
-#### `log_level`
+    ```toml
+    [app]
+    history_file = "/path/to/history_file.history"
+    ```
 
-Level for logging.
+    ----
 
-Type: `str`
+    #### `bulk_mode`
 
-Default: `"ERROR"`
+    Strictness of error handling in bulk operations. If `strict`, the operation will stop at the first error. If `continue`, the operation will continue after errors and report them afterwards. If `skip`, the operation will skip invalid lines in bulk file, as well as ignore all errors when executing the operation.
 
-----
+    Type: `str`
 
-#### `log_file`
+    Choices: `"strict"`, `"continue"`, `"skip"`
 
-File for storing logs.
+    Default: `"strict"`
 
-Type: `str`
+    ```toml
+    [app]
+    bulk_mode = "strict"
+    ```
 
-Default: `"<LOG_DIR>/zabbix-cli.log"`
+    ----
+
+    #### `allow_insecure_auth_file`
+
+    Whether to allow insecure auth files.
+
+    Type: `bool`
+
+    Default: `true`
+
+    ```toml
+    [app]
+    allow_insecure_auth_file = false
+    ```
+
+    ----
+
+    #### `legacy_json_format`
+
+    Whether to use the legacy JSON format (pre-Zabbix CLI 3.0), where the output is a JSON mapping with numeric string keys for each result. See the [migration guide](./migration.md) for more information.
+
+    Type: `bool`
+
+    Default: `false`
+
+    ```toml
+    [app]
+    legacy_json_format = false
+    ```
+
+=== "`app.output`"
+
+    The `app.output` section configures the output format of the application.
+
+    ```toml
+    [app.output]
+    format = "table"
+    color = true
+    paging = false
+    theme = "default"
+    ```
+
+    ----
+
+    #### `format`
+
+    Format of the application output.
+
+    Type: `str`
+
+    Default: `"table"`
+
+    Choices: `"table"`, `"json"`
+
+    ```toml
+    [app.output]
+    format = "table"
+    ```
+
+    ----
+
+    #### `color`
+
+    Whether to use color in the terminal output.
+
+    Type: `bool`
+
+    Default: `true`
+
+    ```toml
+    [app.output]
+    color = false
+    ```
+
+    ----
+
+    #### `paging`
+
+    Whether to use paging in the output.
+
+    Type: `bool`
+
+    Default: `false`
+
+    ```toml
+    [app.output]
+    paging = false
+    ```
+
+=== "`logging`"
+
+    The `logging` section configures logging.
+
+
+    ```toml
+    [logging]
+    enabled = true
+    log_level = "INFO"
+    log_file = "/path/to/zabbix-cli.log"
+    ```
+
+    ----
+
+    #### `enabled`
+
+    Whether logging is enabled.
+
+    Type: `bool`
+
+    Default: `true`
+
+    ```toml
+    [logging]
+    enabled = true
+    ```
+
+    ----
+
+    #### `log_level`
+
+    Level for logging.
+
+    Type: `str`
+
+    Default: `"ERROR"`
+
+    ```toml
+    [logging]
+    log_level = "ERROR"
+    ```
+
+    ----
+
+    #### `log_file`
+
+    File for storing logs. Can be omitted to log to stderr (**warning:** NOISY).
+
+    Type: `Optional[str]`
+
+    Default: `"<LOG_DIR>/zabbix-cli.log"`
+
+    ```toml
+    [logging]
+    log_file = "/path/to/zabbix-cli.log"
+    ```

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,4 +1,4 @@
-# Introduction
+# User Guide
 
 Zabbix CLI is an application that provides a command line interface for interacting with the Zabbix API. Once installed, it can be invoked with `zabbix-cli`.
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-The application is primarily distributed with `pip`, but other installation methods are available.
+The application is primarily distributed with `pip`, but other installation methods are also available.
 
 ## Install
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,7 +95,6 @@ nav:
   - Home:
       - index.md
   - User Guide:
-    - Introduction: guide/introduction.md
     - Installation: guide/installation.md
     - Configuration: guide/configuration.md
     - Authentication: guide/authentication.md

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,16 +2,30 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Type
 from typing import Union
 
 import pytest
+import tomli
 from inline_snapshot import snapshot
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import model_validator
+from typing_extensions import Self
+from zabbix_cli.config.constants import OutputFormat
+from zabbix_cli.config.constants import SecretMode
+from zabbix_cli.config.model import APIConfig
+from zabbix_cli.config.model import AppConfig
 from zabbix_cli.config.model import Config
 from zabbix_cli.config.model import PluginConfig
 from zabbix_cli.config.model import PluginsConfig
+from zabbix_cli.config.utils import DeprecatedField
+from zabbix_cli.config.utils import get_deprecated_fields_set
+from zabbix_cli.config.utils import update_deprecated_fields
 from zabbix_cli.exceptions import ConfigOptionNotFound
 from zabbix_cli.exceptions import PluginConfigTypeError
 
@@ -241,3 +255,312 @@ def test_plugin_config_set() -> None:
             "extra3": False,
         }
     )
+
+
+@pytest.mark.parametrize(
+    "context, expect",
+    [
+        ({"secrets": SecretMode.HIDE}, SecretMode.HIDE),
+        ({"secrets": SecretMode.MASK}, SecretMode.MASK),
+        ({"secrets": SecretMode.PLAIN}, SecretMode.PLAIN),
+        ({"secrets": "hide"}, SecretMode.HIDE),
+        ({"secrets": "mask"}, SecretMode.MASK),
+        ({"secrets": "plain"}, SecretMode.PLAIN),
+        ({}, SecretMode.MASK),
+        (None, SecretMode.MASK),
+        (lambda: {}, SecretMode.MASK),  # type: ignore
+        ({"secrets": True}, SecretMode.PLAIN),
+        ({"secrets": False}, SecretMode.MASK),
+    ],
+)
+def test_secret_mode_from_context(context: Any, expect: SecretMode) -> None:
+    assert SecretMode.from_context(context) == expect
+
+
+def test_secret_mode_default() -> None:
+    assert SecretMode._DEFAULT is SecretMode.MASK  # type: ignore
+
+
+def _get_config_with_secrets() -> Config:
+    return Config(
+        api=APIConfig(
+            username="Admin",
+            password="password",
+            auth_token="token123",
+        )
+    )
+
+
+def test_config_dump_to_file_masked(tmp_path: Path) -> None:
+    conf_file = tmp_path / "zabbix-cli.toml"
+    conf = _get_config_with_secrets()
+    conf.dump_to_file(conf_file, secrets=SecretMode.MASK)
+
+    toml_str = conf_file.read_text()
+    config_dict = tomli.loads(toml_str)
+    assert config_dict["api"]["password"] == snapshot("**********")
+    assert config_dict["api"]["auth_token"] == snapshot("**********")
+
+
+def test_deprecated_field_warnings(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that deprecated fields are logged."""
+    Config(
+        app=AppConfig(
+            output_format=OutputFormat.JSON,
+            use_colors=True,
+            use_paging=True,
+            system_id="System-User",
+        )
+    )
+    assert caplog.record_tuples == snapshot(
+        [
+            (
+                "zabbix_cli",
+                30,
+                "Config option [configopt]output_format[/] is deprecated. Use [configopt]app.output.format[/] instead.",
+            ),
+            (
+                "zabbix_cli",
+                30,
+                "Config option [configopt]system_id[/] is deprecated. Use [configopt]api.username[/] instead.",
+            ),
+            (
+                "zabbix_cli",
+                30,
+                "Config option [configopt]use_colors[/] is deprecated. Use [configopt]app.output.color[/] instead.",
+            ),
+            (
+                "zabbix_cli",
+                30,
+                "Config option [configopt]use_paging[/] is deprecated. Use [configopt]app.output.paging[/] instead.",
+            ),
+            (
+                "zabbix_cli",
+                30,
+                """\
+Your configuration file contains deprecated options.
+  To update your config file with the new options, run:
+  [command]zabbix-cli update_config[/]
+  For more information, see the documentation.\
+""",
+            ),
+        ]
+    )
+
+
+def test_get_deprecated_fields_set() -> None:
+    config = Config(
+        app=AppConfig(
+            output_format=OutputFormat.JSON,
+            use_colors=True,
+            use_paging=True,
+            system_id="System-User",
+        )
+    )
+    # Sort because order of `BaseModel.model_fields_set` is not guaranteed
+    assert sorted(get_deprecated_fields_set(config)) == snapshot(
+        [
+            DeprecatedField(
+                field_name="app.output_format",
+                value=OutputFormat.JSON,
+                replacement="app.output.format",
+            ),
+            DeprecatedField(
+                field_name="app.system_id",
+                value="System-User",
+                replacement="api.username",
+            ),
+            DeprecatedField(
+                field_name="app.use_colors", value=True, replacement="app.output.color"
+            ),
+            DeprecatedField(
+                field_name="app.use_paging", value=True, replacement="app.output.paging"
+            ),
+        ]
+    )
+
+
+def test_get_deprecated_fields_deep_nesting() -> None:
+    """Test that deprecated fields are found in nested models."""
+
+    class Baz(BaseModel):
+        qux: str = ""
+
+    class Bar(BaseModel):
+        baz: Baz = Field(default_factory=Baz)
+        qux_deprecated: str = Field(
+            default="",
+            deprecated=True,
+            json_schema_extra={"replacement": "bar.baz.qux"},
+        )
+
+    class Foo(BaseModel):
+        bar: Bar = Field(default_factory=Bar)
+
+        # Copied from zabbix_cli.config.model.Config
+        # TODO: to test this better, we could declare a new BaseModel
+        # subclass intended for top-level models which automatically implement
+        # this validator. That way we can be sure the validator behavior
+        # in the test is consistent with the behavior in the actual code.
+        @model_validator(mode="after")
+        def _set_deprecated_fields_in_new_location(self) -> Self:
+            """Set deprecated fields in their new location."""
+            update_deprecated_fields(self)
+            return self
+
+    foo = Foo(bar=Bar(qux_deprecated="test123"))
+
+    # Deprecated field should be found
+    assert sorted(get_deprecated_fields_set(foo)) == snapshot(
+        [
+            DeprecatedField(
+                field_name="bar.qux_deprecated",
+                value="test123",
+                replacement="bar.baz.qux",
+            )
+        ]
+    )
+
+    # Deprecated field should be automatically assigned to the new field
+    assert foo.model_dump() == snapshot(
+        {"bar": {"baz": {"qux": "test123"}, "qux_deprecated": "test123"}}
+    )
+
+
+def test_deprecated_fields_updated() -> None:
+    """Test that deprecated fields are assigned to the new fields if specified."""
+    conf = Config(
+        app=AppConfig(
+            # Set fields to non-default values for comparison
+            output_format=OutputFormat.JSON,
+            use_colors=False,
+            use_paging=True,
+            system_id="System-User",
+        )
+    )
+    assert sorted(conf.app.model_fields_set) == snapshot(
+        ["output_format", "system_id", "use_colors", "use_paging"]
+    )
+    assert sorted(conf.app.output.model_fields_set) == snapshot(
+        ["color", "format", "paging"]
+    )
+    assert conf.app.output.format == OutputFormat.JSON
+    assert conf.app.output.color is False
+    assert conf.app.output.paging is True
+    assert conf.api.username == "System-User"
+
+
+def get_deprecated_fields(model: Union[Type[BaseModel], BaseModel]) -> List[str]:
+    """Get a set of names of deprecated fields in a model and its submodels."""
+    fields: List[str] = []
+    for field_name, field in model.model_fields.items():
+        if field.deprecated:
+            fields.append(field_name)
+        if not field.annotation:
+            continue
+        try:
+            if issubclass(field.annotation, BaseModel):
+                submodel_fields = get_deprecated_fields(field.annotation)
+                fields.extend(
+                    f"{field_name}.{subfield}" for subfield in submodel_fields
+                )
+        except TypeError:
+            pass
+    return fields
+
+
+def test_get_deprecated_fields() -> None:
+    """Ensure we are aware of all deprecated fields in the Config model"""
+    assert get_deprecated_fields(Config) == snapshot(
+        ["app.output_format", "app.use_colors", "app.use_paging", "app.system_id"]
+    )
+
+
+def test_load_deprecated_config(tmp_path: Path) -> None:
+    conf = tmp_path / "zabbix-cli.toml"
+    conf.write_text(
+        f"""
+[api]
+url = "http://localhost:8080"
+
+# No username option specified (assigned from app.system_id)
+
+password = ""
+auth_token = ""
+verify_ssl = true
+
+[app]
+default_hostgroups = ["All-hosts"]
+default_admin_usergroups = []
+default_create_user_usergroups = []
+default_notification_users_usergroups = ["All-notification-users"]
+export_directory = "{tmp_path}/exports"
+export_format = "json"
+export_timestamps = false
+use_auth_token_file = true
+auth_token_file = "{tmp_path}/.zabbix-cli_auth_token"
+auth_file = "{tmp_path}/.zabbix-cli_auth"
+history = true
+history_file = "/Users/pederhan/Library/Application Support/zabbix-cli/history"
+bulk_mode = "strict"
+
+# Deprecated options (moved)
+use_colors = false
+use_paging = true
+output_format = "json"
+system_id = "System-User"
+
+# Deprecated options (slated for removal)
+allow_insecure_auth_file = true
+legacy_json_format = false
+
+# No [app.output] section specified (assigned from deprecated app options)
+
+[logging]
+enabled = true
+log_level = "DEBUG"
+log_file = "{tmp_path}/zabbix-cli.log"
+
+[plugins]
+"""
+    )
+    # Check that we can actually load the config
+    config = Config.from_file(conf)
+
+    # Check that the deprecated fields are assigned to the new fields
+    assert config.app.output.color is False
+    assert config.app.output.paging is True
+    assert config.app.output.format == OutputFormat.JSON
+    assert config.api.username == "System-User"
+
+
+def test_load_deprecated_config_with_new_and_old_options(tmp_path: Path) -> None:
+    """Test loading a config file where both new and deprecated options are present.
+
+    The deprecated options should _not_ be assigned to the new options, as the new options
+    are already set"""
+    conf = tmp_path / "zabbix-cli.toml"
+    conf.write_text(
+        """
+[api]
+username = "Admin"
+
+[app]
+use_colors = false
+use_paging = true
+output_format = "json"
+system_id = "System-User"
+
+[app.output]
+color = true
+format = "table"
+paging = false
+"""
+    )
+    config = Config.from_file(conf)
+
+    # New fields should NOT be overwritten by deprecated fields
+    assert config.api.username == "Admin"
+    assert config.app.output.color is True
+    assert config.app.output.paging is False
+    assert config.app.output.format == OutputFormat.TABLE

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -501,7 +501,7 @@ use_auth_token_file = true
 auth_token_file = "{tmp_path}/.zabbix-cli_auth_token"
 auth_file = "{tmp_path}/.zabbix-cli_auth"
 history = true
-history_file = "/Users/pederhan/Library/Application Support/zabbix-cli/history"
+history_file = "{tmp_path}/history"
 bulk_mode = "strict"
 
 # Deprecated options (moved)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -66,8 +66,9 @@ def test_get_extra_dict_reserved_keys() -> None:
 
 
 def test_debug_kv(
-    capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture, state: State
 ) -> None:
+    state.config.logging.log_level = "DEBUG"
     caplog.set_level(logging.DEBUG)
     debug_kv("some", "error")
     captured = capsys.readouterr()
@@ -79,8 +80,9 @@ def test_debug_kv(
 
 
 def test_debug(
-    capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture, state: State
 ) -> None:
+    state.config.logging.log_level = "DEBUG"
     caplog.set_level(logging.DEBUG)
     debug("Some error")
     captured = capsys.readouterr()
@@ -136,8 +138,7 @@ def test_error(
 def test_exit_err_table(
     capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture, state: State
 ) -> None:
-    assert state.is_config_loaded is True
-    state.config.app.output_format = OutputFormat.TABLE
+    state.config.app.output.format = OutputFormat.TABLE
     caplog.set_level(logging.INFO)
     with pytest.raises(SystemExit):
         exit_err("Some error")
@@ -149,7 +150,7 @@ def test_exit_err_table(
 def test_exit_err_json(
     capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture, state: State
 ) -> None:
-    state.config.app.output_format = OutputFormat.JSON
+    state.config.app.output.format = OutputFormat.JSON
     with pytest.raises(SystemExit):
         exit_err("Some error")
     captured = capsys.readouterr()
@@ -173,7 +174,7 @@ def test_exit_err_json_with_errors(
     outer_exc = TypeError("Outer exception")
     outer_exc.__cause__ = ValueError("Inner exception")
 
-    state.config.app.output_format = OutputFormat.JSON
+    state.config.app.output.format = OutputFormat.JSON
     with pytest.raises(SystemExit):
         exit_err("Some error", exception=outer_exc)
     captured = capsys.readouterr()
@@ -210,7 +211,7 @@ def test_exit_err_json_with_zabbix_api_request_error(
         "Inner exception", api_response=api_resp
     )
 
-    state.config.app.output_format = OutputFormat.JSON
+    state.config.app.output.format = OutputFormat.JSON
     with pytest.raises(SystemExit):
         exit_err("Some error", exception=outer_exc)
     captured = capsys.readouterr()

--- a/zabbix_cli/commands/export.py
+++ b/zabbix_cli/commands/export.py
@@ -624,7 +624,7 @@ def import_configuration(
     # TODO: print properly with just render_result instead of this hack
     if dry_run:
         msg = f"Found {len(files)} files to import"
-        if app.state.config.app.output_format == OutputFormat.TABLE:
+        if app.state.config.app.output.format == OutputFormat.TABLE:
             to_print = [path_link(f) for f in files]
             console.print("\n".join(to_print), highlight=False, no_wrap=True)
             info(msg)

--- a/zabbix_cli/commands/macro.py
+++ b/zabbix_cli/commands/macro.py
@@ -152,7 +152,7 @@ def show_usermacro_host_list(
     # command is to list _all_ hosts with the given macro, so we want to render
     # the macro and a list of EVERY host with that macro.
     if (
-        app.state.config.app.output_format == OutputFormat.JSON
+        app.state.config.app.output.format == OutputFormat.JSON
         and app.state.config.app.legacy_json_format
     ):
         render_result(

--- a/zabbix_cli/config/constants.py
+++ b/zabbix_cli/config/constants.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Optional
+from typing import Union
 
 from strenum import StrEnum
 
 from zabbix_cli.dirs import CONFIG_DIR
 from zabbix_cli.dirs import DATA_DIR
 from zabbix_cli.dirs import SITE_CONFIG_DIR
+
+logger = logging.getLogger("zabbix_cli.config")
 
 # Config file basename
 CONFIG_FILENAME = "zabbix-cli.toml"
@@ -38,3 +46,36 @@ class OutputFormat(StrEnum):
     CSV = "csv"
     JSON = "json"
     TABLE = "table"
+
+
+class SecretMode(StrEnum):
+    """Mode for serializing secrets."""
+
+    HIDE = "hide"
+    MASK = "masked"
+    PLAIN = "plain"
+
+    _DEFAULT = MASK
+
+    @classmethod
+    def from_context(
+        cls, context: Optional[Union[Dict[str, Any], Callable[..., Dict[str, Any]]]]
+    ) -> SecretMode:
+        """Get the secret mode from a serialization context."""
+        if isinstance(context, dict) and (ctx := context.get("secrets")) is not None:
+            # Support for old-style context values (true/false)
+            # as well as new context values (enum values)
+            try:
+                if isinstance(ctx, SecretMode):
+                    return ctx
+                elif ctx is True:
+                    return cls.PLAIN
+                elif ctx is False:
+                    return cls.MASK
+                else:
+                    return cls(str(ctx).lower())
+            except ValueError:
+                logger.warning(
+                    "Got invalid secret mode from context %s: %s", context, ctx
+                )
+        return cls._DEFAULT

--- a/zabbix_cli/exceptions.py
+++ b/zabbix_cli/exceptions.py
@@ -132,8 +132,12 @@ class ZabbixAPIRequestError(ZabbixAPIException):
         return reason
 
 
-class ZabbixAPITokenExpired(ZabbixAPIRequestError):
+class ZabbixAPITokenExpiredError(ZabbixAPIRequestError):
     """Zabbix API token expired error."""
+
+
+class ZabbixAPINotAuthorizedError(ZabbixAPIRequestError):
+    """Zabbix API not authorized error."""
 
 
 class ZabbixAPIResponseParsingError(ZabbixAPIRequestError):

--- a/zabbix_cli/logs.py
+++ b/zabbix_cli/logs.py
@@ -133,7 +133,9 @@ def get_file_handler_safe(filename: Path) -> logging.Handler:
         mkdir_if_not_exists(filename.parent)
         return logging.FileHandler(filename)
     except Exception as e:
-        logger.error("Could not open log file %s for writing: %s", filename, e)
+        from zabbix_cli.output.console import error
+
+        error(f"Could not open log file {filename} for writing: {e}")
         return logging.StreamHandler()
 
 

--- a/zabbix_cli/main.py
+++ b/zabbix_cli/main.py
@@ -34,6 +34,7 @@ from zabbix_cli.__about__ import __version__
 from zabbix_cli.app import app
 from zabbix_cli.config.constants import OutputFormat
 from zabbix_cli.config.utils import get_config
+from zabbix_cli.logs import configure_logging
 from zabbix_cli.logs import logger
 from zabbix_cli.state import get_state
 
@@ -133,7 +134,7 @@ def main_callback(
 
     # Config overrides are always applied
     if output_format is not None:
-        state.config.app.output_format = output_format
+        state.config.app.output.format = output_format
 
     if state.repl or state.bulk:
         return  # In REPL or bulk mode already; no need to re-configure.
@@ -227,6 +228,7 @@ def main() -> int:
         # - configure logging
         # - configure console output
         # - load local plugins (defined in the config)
+        configure_logging()
         conf = _parse_config_arg()
         config = get_config(conf, init=False)
         state.config = config

--- a/zabbix_cli/output/console.py
+++ b/zabbix_cli/output/console.py
@@ -197,5 +197,5 @@ def enable_color() -> None:
 
 def configure_console(config: Config) -> None:
     """Configure console output based on the application configuration."""
-    if not config.app.use_colors:
+    if not config.app.output.color:
         disable_color()

--- a/zabbix_cli/output/console.py
+++ b/zabbix_cli/output/console.py
@@ -147,7 +147,7 @@ def exit_err(
     state = get_state()
 
     # Render JSON-formatted error message if output format is JSON
-    if state.is_config_loaded and state.config.app.output_format == "json":
+    if state.config.app.output.format == "json":
         from zabbix_cli.exceptions import get_cause_args
         from zabbix_cli.models import Result
         from zabbix_cli.models import ReturnCode

--- a/zabbix_cli/output/render.py
+++ b/zabbix_cli/output/render.py
@@ -56,7 +56,7 @@ def render_result(
 
     # Short form aliases
     state = get_state()
-    fmt = state.config.app.output_format
+    fmt = state.config.app.output.format
     # paging = state.config.output.paging
     paging = False  # TODO: implement
 

--- a/zabbix_cli/state.py
+++ b/zabbix_cli/state.py
@@ -126,7 +126,6 @@ class State:
     def config(self, config: Config) -> None:
         """Set the configuration object and update active configuration of
         loggers, consoles, etc."""
-        from zabbix_cli.config.model import Config
         from zabbix_cli.logs import configure_logging
         from zabbix_cli.output.console import configure_console
 
@@ -135,7 +134,7 @@ class State:
         configure_console(config)
         # HACK: don't consider using sample config as "loaded".
         # Signals that main callback should create a new config file.
-        self._config_loaded = config != Config.sample_config()
+        self._config_loaded = config.sample is False
 
     @property
     def is_config_loaded(self) -> bool:


### PR DESCRIPTION
This PR moves some `[app]` configuration options to a new table `[app.output]`. In tandem with that, it adds deprecation warnings for usage of deprecated configuration options, as well as automatic migration internally of config option values, i.e.

```toml
[app]
use_colors = true
use_paging = false
output_format = "json"
```

Is automatically migrated internally in the `Config` class, so that it's as if the user had this configuration file:

```toml
[app.output]
color = true
paging = false
format = "json"
```

We are able to do this by marking the relevant fields as `deprecated=True`, as well as providing `json_schema_extra={"replacement": "<new.location.relative.to.root>"}`. For example, for `AppConfig.use_colors` we have the following field definition:

```py
class AppConfig(BaseModel):
    use_colors: bool = Field(
        default=True,
        deprecated=True,
        json_schema_extra={"replacement": "app.output.color"},
        exclude=True,
    )
```

Where the replacement path is relative to the attributes of `Config`. Tests have been added to ensure this migration happens automatically and as expected.