### PR TITLE
Docs: Simplify README, move to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Zabbix-cli is a command line interface for Zabbix. It can be used in three ways:
 
 Command reference can be found in the [online user guide](https://unioslo.github.io/zabbix-cli/guide/introduction/) or by running `zabbix-cli --help`.
 
+### Authentication
+
+By default, the application will prompt for a username and password. Once authenticated, the application stores the session token in a file for future use.
+
+For more information about the various authentication methods, see the [authentication guide](https://unioslo.github.io/zabbix-cli/guide/authentication/).
+
 ## Formats
 
 Zabbix-cli supports two output formats: table and JSON. The default format is table, but it can be changed with the `--format` parameter:
@@ -143,168 +149,13 @@ The type of the `result` field varies based on the command run. For `show_host` 
 
 ## Configuration
 
-Zabbix-cli needs a config file. This can be created with the `zabbix-cli init` command.
+Zabbix-cli needs a config file. It is created when the application is started for the first time. The config file can be created manually with the `init` command:
 
 ```bash
 zabbix-cli init --zabbix-url https://zabbix.example.com/
 ```
 
-Zabbix-cli will look for config files in the following order:
-
-1. The path specified with the `--config` parameter
-2. `./zabbix-cli.toml`
-3. XDG config directory (usually `~/.config/zabbix-cli/zabbix-cli.toml`), or equivalent Platformdirs directory on [Windows](https://platformdirs.readthedocs.io/en/latest/api.html#windows) and [macOS](https://platformdirs.readthedocs.io/en/latest/api.html#macos)
-4. XDG site config directory (usually `/etc/xdg/zabbix-cli/zabbix-cli.toml`), or equivalent Platformdirs directory on [Windows](https://platformdirs.readthedocs.io/en/latest/api.html#windows) and [macOS](https://platformdirs.readthedocs.io/en/latest/api.html#macos)
-
-To show the directories used by the application run:
-
-```
-zabbix-cli show_dirs
-```
-
-To open the default config directory with the default window manager run:
-
-```bash
-zabbix-cli open config
-```
-
-Or print the path to the default config directory:
-
-```bash
-zabbix-cli open config --path
-```
-
-Zabbix-cli provides commands for showing the current and default configuration:
-
-```bash
-zabbix-cli show_config
-zabbix-cli sample_config
-```
-
-If you run into problems it is useful to enable debug logging in the config file:
-
-```toml
-[logging]
-enabled = true
-log_level = "DEBUG"
-```
-
-Find the log file with:
-
-```bash
-zabbix-cli open logs
-```
-
-## Authentication
-
-Zabbix-cli provides several ways to authenticate. They are tried in the following order if multiple are set:
-
-1. [API token from config file](#api-token-config-file)
-2. [API token from environment variables](#api-token-environment-variables)
-3. [Auth token from auth token file](#auth-token-file)
-4. [Username and password from config file](#config-file)
-5. [Username and password from auth file](#auth-file)
-6. [Username and password from environment variables](#environment-variables)
-7. [Username and password from prompt](#prompt)
-
-### Username and Password
-
-Password-based authentication is the default way to authenticate with Zabbix-cli. If the application is unable to determine authentication from other sources, it will prompt for a username and password.
-
-#### Config file
-
-The password can be set directly in the config file:
-
-```toml
-[api]
-zabbix_url = "https://zabbix.example.com/"
-username = "Admin"
-password = "zabbix"
-```
-
-#### Auth file
-
-An auth file named `.zabbix-cli_auth` can be created in the user's home directory. The content of this file should be in the `USERNAME::PASSWORD` format.
-
-```bash
-echo "Admin::zabbix" > ~/.zabbix-cli_auth
-```
-
-The location of this file can be changed in the config file:
-
-```toml
-[app]
-auth_file = "/path/to/auth/file"
-```
-
-#### Environment variables
-
-The username and password can be set as environment variables:
-
-```bash
-export ZABBIX_USERNAME="Admin"
-export ZABBIX_PASSWORD="zabbix"
-```
-
-#### Prompt
-
-By omitting the `password` parameter in the config file or when all other authentication methods have been exhausted, you will be prompted for a password when starting zabbix-cli:
-
-```toml
-[api]
-zabbix_url = "https://zabbix.example.com/"
-username = "Admin"
-```
-
-### API token
-
-API token authentication foregoes the need for a username and password. The token can be an API token created in the web frontend or a user's session token obtained by logging in.
-
-#### API token (config file)
-
-API token can be specified directly in the config file:
-
-```toml
-[api]
-auth_token = "API_TOKEN"
-```
-
-#### API token (environment variables)
-
-API token can be specified as an environment variable:
-
-```bash
-export ZABBIX_API_TOKEN="API TOKEN"
-```
-
-#### Auth token file
-
-The application can store the session token returned by the Zabbix API when logging in to a file on your computer. The file is then used for subsequent sessions to authenticate with the Zabbix API.
-
-This feature useful when authenticating with a username and password from a prompt, which would otherwise require you to enter your password every time you start the application.
-
-The feature is enabled by default in the config file:
-
-```toml
-[app]
-use_auth_token_file = true
-```
-
-The location of the auth token file can be changed in the config file:
-
-```toml
-[app]
-auth_token_file = "/path/to/auth/token/file"
-```
-
-By default, the auth token file is not required to have secure permissions. If you want to require the file to have `600` (rw-------) permissions, you can set `allow_insecure_auth_file=false` in the config file. This has no effect on Windows.
-
-```toml
-[app]
-allow_insecure_auth_file = false
-```
-
-Zabbix-cli attempts to set `600` permissions when writing the auth token file if `allow_insecure_auth_file=false`.
+For more information about the configuration file, see the [configuration guide](https://unioslo.github.io/zabbix-cli/guide/configuration/).
 
 ## Development
 

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -1,18 +1,66 @@
 # Authentication
 
-Zabbix-cli provides several ways to authenticate. They are tried in the following order if multiple are set:
+Zabbix-cli provides several ways to authenticate. They are tried in the following order:
 
-1. [API token from config file](#api-token-config-file)
-2. [API token from environment variables](#api-token-environment-variables)
-3. [Auth token from auth token file](#auth-token-file)
-4. [Username and password from config file](#config-file)
-5. [Username and password from auth file](#auth-file)
-6. [Username and password from environment variables](#environment-variables)
-7. [Username and password from prompt](#prompt)
+1. [Token - Config file](#api-token-config-file)
+1. [Token - Environment variables](#api-token-environment-variables)
+1. [Token - Auth token file](#auth-token-file)
+1. [Password - Config file](#config-file_1)
+1. [Password - Auth file](#auth-file)
+1. [Password - Environment variables](#environment-variables_1)
+1. [Password - Prompt](#prompt)
+
+## Token
+
+The application supports authenticating with an API or session token. API tokens are created in the Zabbix frontend or via `zabbix-cli create_token`. A session token is obtained by logging in to the Zabbix API with a username and password.
+
+!!! info "Session vs API token"
+    Semantically, a session token and API token are the same thing from an API authentication perspective. They are both sent as the `auth` parameter in the Zabbix API requests.
+
+### Config file
+
+The token can be set directly in the config file:
+
+```toml
+[api]
+auth_token = "API_TOKEN"
+```
+
+### Environment variables
+
+The API token can be set as an environment variable:
+
+```bash
+export ZABBIX_API_TOKEN="API TOKEN"
+```
+
+### Auth token file
+
+The application can store and reuse session tokens between runs. This feature is enabled by default and configurable via the following options:
+
+```toml
+[app]
+# Enable token file storage (default: true)
+use_auth_token_file = true
+
+# Customize token file location (optional)
+auth_token_file = "/path/to/auth/token/file"
+
+# Enforce secure file permissions (default: true, no effect on Windows)
+allow_insecure_auth_file = false
+```
+
+**How it works:**
+
+- Log in once with username and password
+- Token is automatically saved to the file
+- Subsequent runs will use the saved token for authentication
+
+When `allow_insecure_auth_file` is set to `false`, the application will attempt to set `600` (read/write for owner only) permissions on the token file when creating/updating it.
 
 ## Username and Password
 
-Password-based authentication is the default way to authenticate with Zabbix-cli. If the application is unable to determine authentication from other sources, it will prompt for a username and password.
+The application supports authenticating with a username and password. The password can be set in the config file, an auth file, as environment variables, or prompted for when starting the application.
 
 ### Config file
 
@@ -20,24 +68,23 @@ The password can be set directly in the config file:
 
 ```toml
 [api]
-zabbix_url = "https://zabbix.example.com/"
 username = "Admin"
 password = "zabbix"
 ```
 
 ### Auth file
 
-An auth file named `.zabbix-cli_auth` can be created in the user's home directory. The content of this file should be in the `USERNAME::PASSWORD` format.
+A file named `.zabbix-cli_auth` can be created in the user's home directory or in the application's data directory. The file should contain a single line of text in the format `USERNAME::PASSWORD`.
 
 ```bash
 echo "Admin::zabbix" > ~/.zabbix-cli_auth
 ```
 
-The location of this file can be changed in the config file:
+The location of the auth file file can be changed in the config file:
 
 ```toml
 [app]
-auth_file = "/path/to/auth/file"
+auth_file = "~/.zabbix-cli_auth"
 ```
 
 ### Environment variables
@@ -51,60 +98,9 @@ export ZABBIX_PASSWORD="zabbix"
 
 ### Prompt
 
-By omitting the `password` parameter in the config file or when all other authentication methods have been exhausted, you will be prompted for a password when starting zabbix-cli:
+When all other authentication methods fail, the application will prompt for a username and password. The default username in the prompt can be configured:
 
 ```toml
 [api]
-zabbix_url = "https://zabbix.example.com/"
 username = "Admin"
 ```
-
-## API token
-
-API token authentication foregoes the need for a username and password. The token can be an API token created in the web frontend or a user's session token obtained by logging in.
-
-### API token (config file)
-
-API token can be specified directly in the config file:
-
-```toml
-[api]
-auth_token = "API_TOKEN"
-```
-
-### API token (environment variables)
-
-API token can be specified as an environment variable:
-
-```bash
-export ZABBIX_API_TOKEN="API TOKEN"
-```
-
-### Auth token file
-
-The application can store the session token returned by the Zabbix API when logging in to a file on your computer. The file is then used for subsequent sessions to authenticate with the Zabbix API.
-
-This feature useful when authenticating with a username and password from a prompt, which would otherwise require you to enter your password every time you start the application.
-
-The feature is enabled by default in the config file:
-
-```toml
-[app]
-use_auth_token_file = true
-```
-
-The location of the auth token file can be changed in the config file:
-
-```toml
-[app]
-auth_token_file = "/path/to/auth/token/file"
-```
-
-By default, the auth token file is not required to have secure permissions. If you want to require the file to have `600` (rw-------) permissions, you can set `allow_insecure_auth_file=false` in the config file. This has no effect on Windows.
-
-```toml
-[app]
-allow_insecure_auth_file = false
-```
-
-Zabbix-cli attempts to set `600` permissions when writing the auth token file if `allow_insecure_auth_file=false`.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,14 +1,23 @@
 # Configuration
 
-The application is configured with a TOML file. The default location is platform-dependent.
+!!! note "Configuration file directory"
+    The application uses the [platformdirs](https://pypi.org/project/platformdirs/) package to determine the configuration directory.
+
+The application is configured with a TOML file. The file is created on startup if it doesn't exist.
+
+The configuration file is searched for in the following locations:
 
 {% include ".includes/config-locations.md" %}
 
+<!-- TODO: Gather the different paths in CI, then combine them to construct the config-locations.md file -->
+
 ## Create a config
 
-Before using the application, a configuration file must be created. This can be done with the `init` command:
+The configuration file is automatically created when the application is started for the first time.
 
-```
+The config file can also manually be created with the `init` command:
+
+```bash
 zabbix-cli init
 ```
 
@@ -16,8 +25,8 @@ The application will print the location of the created configuration file.
 
 To bootstrap the config with a URL and username, use the options `--url` and `--user`:
 
-```
-zabbix-cli-init --url https://zabbix.example.com --user Admin
+```bash
+zabbix-cli init --url https://zabbix.example.com --user Admin
 ```
 
 To overwrite an existing configuration file, use the `--overwrite` option:
@@ -511,6 +520,8 @@ To do this, we need to add Field() for every field in the model, and also ensure
     Type: `str`
 
     Default: `"ERROR"`
+
+    Choices: `"DEBUG"`, `"INFO"`, `"WARNING"`, `"ERROR"`, `"CRITICAL"`
 
     ```toml
     [logging]

--- a/docs/guide/logging.md
+++ b/docs/guide/logging.md
@@ -1,0 +1,58 @@
+# Logging
+
+The application supports logging to a file or directly to the terminal. By default, file logging is enabled and set to the `ERROR` level.
+
+## Enable/disable logging
+
+Logging is enabled by default. To disable logging, set the `enabled` option to `false` in the configuration file:
+
+```toml
+[logging]
+enabled = true
+```
+
+## Levels
+
+The application only logs messages with a level equal to or higher than the configured level. By default, the level is set to `ERROR`. The available levels are:
+
+- `DEBUG`
+- `INFO`
+- `WARNING`
+- `ERROR`
+- `CRITICAL`
+
+The level can be set in the configuration file:
+
+```toml
+[logging]
+level = "DEBUG"
+```
+
+## Log file
+
+The default location of the log file is a file named `zabbix-cli.log` in the application's logs directory.
+
+The log file location can be changed in the configuration file:
+
+```toml
+[logging]
+log_file = "/path/to/zabbix-cli.log"
+```
+
+The default logs directory can be opened with the command:
+
+```bash
+zabbix-cli open logs
+```
+
+## Log to terminal
+
+!!! warning "Verbose output"
+    Logging to the terminal can produce a lot of output, especially when the log level is set to `DEBUG`. Furthermore, some of the output messages may be shown twice, as they are printed once by the application and once by the logging library.
+
+If the `log_file` option is set to an empty string or an invalid file path, the application will log to the terminal instead of a file.
+
+```toml
+[logging]
+log_file = ""
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
     - Configuration: guide/configuration.md
     - Authentication: guide/authentication.md
     - Usage: guide/usage.md
+    - Logging: guide/logging.md
     - Bulk Operations: guide/bulk.md
     - Migration: guide/migration.md
     - Commands:


### PR DESCRIPTION
This PR moves the most verbose authentication and configuration sections of the README to the documentation. Furthermore, it adds a new page called "Logging" to the documentation.