### PR TITLE
Add `update` support for macOS x86_64 pyinstaller binaries

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -2,31 +2,17 @@ from __future__ import annotations
 
 import pytest
 from zabbix_cli.update import PyInstallerUpdater
-from zabbix_cli.update import UpdateError
 
 
 @pytest.mark.parametrize(
     "os, arch, version, expect_info",
     [
         ("linux", "x86_64", "1.2.3", "1.2.3-linux-x86_64"),
+        ("linux", "arm64", "1.2.3", "1.2.3-linux-arm64"),
+        ("linux", "armv7l", "1.2.3", "1.2.3-linux-armv7l"),
         ("darwin", "x86_64", "1.2.3", "1.2.3-macos-x86_64"),
         ("darwin", "arm64", "1.2.3", "1.2.3-macos-arm64"),
         ("win32", "x86_64", "1.2.3", "1.2.3-win-x86_64.exe"),
-        # Unsupported platforms
-        pytest.param(
-            "linux",
-            "arm64",
-            "1.2.3",
-            "1.2.3-linux-arm64",
-            marks=pytest.mark.xfail(raises=UpdateError, strict=True),
-        ),
-        pytest.param(
-            "linux",
-            "armv7l",
-            "1.2.3",
-            "1.2.3-linux-armv7l",
-            marks=pytest.mark.xfail(raises=UpdateError, strict=True),
-        ),
     ],
 )
 def test_pyinstaller_updater_get_url(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+from zabbix_cli.update import PyInstallerUpdater
+from zabbix_cli.update import UpdateError
+
+
+@pytest.mark.parametrize(
+    "os, arch, version, expect_info",
+    [
+        ("linux", "x86_64", "1.2.3", "1.2.3-linux-x86_64"),
+        ("darwin", "x86_64", "1.2.3", "1.2.3-macos-x86_64"),
+        ("darwin", "arm64", "1.2.3", "1.2.3-macos-arm64"),
+        ("win32", "x86_64", "1.2.3", "1.2.3-win-x86_64.exe"),
+        # Unsupported platforms
+        pytest.param(
+            "linux",
+            "arm64",
+            "1.2.3",
+            "1.2.3-linux-arm64",
+            marks=pytest.mark.xfail(raises=UpdateError, strict=True),
+        ),
+        pytest.param(
+            "linux",
+            "armv7l",
+            "1.2.3",
+            "1.2.3-linux-armv7l",
+            marks=pytest.mark.xfail(raises=UpdateError, strict=True),
+        ),
+    ],
+)
+def test_pyinstaller_updater_get_url(
+    os: str, arch: str, version: str, expect_info: str
+):
+    BASE_URL = (
+        "https://github.com/unioslo/zabbix-cli/releases/latest/download/zabbix-cli"
+    )
+    expect_url = f"{BASE_URL}-{expect_info}"
+
+    url = PyInstallerUpdater.get_url(os, arch, version)
+    assert url == expect_url

--- a/zabbix_cli/commands/cli.py
+++ b/zabbix_cli/commands/cli.py
@@ -342,10 +342,11 @@ def update_application(ctx: typer.Context) -> None:
 
     Primarily intended for use with PyInstaller builds, but can also be
     used for updating other installations (except Homebrew)."""
+    from zabbix_cli.__about__ import __version__
     from zabbix_cli.update import update
 
     info = update()
-    if info:
-        success(f"Application updated to {info.version}")
+    if info and info.version:
+        success(f"Application updated from {__version__} to {info.version}")
     else:
         success("Application updated.")

--- a/zabbix_cli/utils/fs.py
+++ b/zabbix_cli/utils/fs.py
@@ -5,7 +5,9 @@ import os
 import re
 import subprocess
 import sys
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Generator
 from typing import Optional
 
 from zabbix_cli.exceptions import ZabbixCLIError
@@ -88,3 +90,46 @@ def sanitize_filename(filename: str) -> str:
     Does not check for reserved names or path length.
     """
     return re.sub(r"[^\w\-.]", "_", filename)
+
+
+# NOTE: Move to zabbix_cli.utils.fs?
+def make_executable(path: Path) -> None:
+    """Make a file executable."""
+    if sys.platform == "win32":
+        logger.debug("Skipping making file %s executable on Windows", path)
+        return
+
+    if not path.exists():
+        raise ZabbixCLIFileNotFoundError(
+            f"File {path} does not exist. Unable to make it executable."
+        )
+    mode = path.stat().st_mode
+    new_mode = mode | (mode & 0o444) >> 2  # copy R bits to X
+    if new_mode != mode:
+        path.chmod(new_mode)
+        logger.info("Changed file mode of %s from %o to %o", path, mode, new_mode)
+    else:
+        logger.debug("File %s is already executable", path)
+
+
+def move_file(src: Path, dest: Path, mkdir: bool = True) -> None:
+    """Move a file to a new location."""
+    try:
+        if mkdir:
+            mkdir_if_not_exists(dest.parent)
+        src.rename(dest)
+    except Exception as e:
+        raise ZabbixCLIError(f"Failed to move {src} to {dest}: {e}") from e
+    else:
+        logger.info(f"Moved {src} to {dest}")
+
+
+@contextmanager
+def temp_directory() -> Generator[Path, None, None]:
+    """Context manager for creating a temporary directory.
+
+    Ripped from: https://github.com/pypa/hatch/blob/35f8ffdacc937bdcf3b250e0be1bbdf5cde30c4c/src/hatch/utils/fs.py#L112-L117"""
+    from tempfile import TemporaryDirectory
+
+    with TemporaryDirectory() as d:
+        yield Path(d).resolve()


### PR DESCRIPTION
Adds support for macOS x86_64 binaries to `zabbix-cli update`, as well as adhering to the new URL scheme for artifacts from version >3.2.0 (#240).

Tests have been added to ensure the resolved URLs match the new release artifact scheme.