### PR TITLE
Make `local_{address,port}` args optional for `add_proxy_to_group`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Authentication method + source is now logged on successful authentication.
 - No longer attempts to add a user to the logging context when logging in with an auth token.
 - Require at least one option to be set for `update_*` commands. Previously, these command would state that the resource was updated even if no changes were made.
+- Command `add_proxy_to_group` no longer requires a local address and port argument. If not provided, the application attempts to use the proxy's `local_address` and `local_port` fields. If the proxy does not have these fields, the command fails.
 
 ### Deprecated
 

--- a/zabbix_cli/commands/proxy.py
+++ b/zabbix_cli/commands/proxy.py
@@ -554,10 +554,12 @@ def add_proxy_to_group(
         show_default=False,
     ),
     local_address: Optional[str] = typer.Argument(
+        None,
         help="Address for active agents.",
         show_default=False,
     ),
     local_port: Optional[str] = typer.Argument(
+        None,
         help="Address for active agents.",
         show_default=False,
     ),
@@ -574,10 +576,10 @@ def add_proxy_to_group(
     # Determine address + port
     local_address = local_address or proxy.local_address
     if not local_address:
-        exit_err("Proxy requires a local address for active agents.")
+        exit_err(f"Proxy {proxy.name} requires a local address for active agents.")
     local_port = local_port or proxy.local_port
     if not local_port:
-        exit_err("Proxy requires a local port for active agents.")
+        exit_err(f"Proxy {proxy.name} requires a local port for active agents.")
 
     group = app.state.client.get_proxy_group(proxy_group)
     app.state.client.add_proxy_to_group(proxy, group, local_address, local_port)


### PR DESCRIPTION
These should have been optional to begin with - the docstring even says so!