### PR TITLE
fix: Don't print message in `open` in headless mode

### DIFF
--- a/zabbix_cli/commands/cli.py
+++ b/zabbix_cli/commands/cli.py
@@ -135,7 +135,6 @@ def open_config_dir(
         print_path(directory)
     else:
         open_directory(directory, command=open_command, force=force)
-        success(f"Opened {directory}")
 
 
 @app.command("debug", hidden=True, rich_help_panel=HELP_PANEL)

--- a/zabbix_cli/utils/fs.py
+++ b/zabbix_cli/utils/fs.py
@@ -13,6 +13,8 @@ from typing import Optional
 from zabbix_cli.exceptions import ZabbixCLIError
 from zabbix_cli.exceptions import ZabbixCLIFileError
 from zabbix_cli.exceptions import ZabbixCLIFileNotFoundError
+from zabbix_cli.output.console import print_path
+from zabbix_cli.output.console import success
 
 logger = logging.getLogger(__name__)
 
@@ -59,13 +61,11 @@ def open_directory(
     elif sys.platform == "darwin":
         subprocess.run([command or "open", spath])
     else:  # Linux and Unix
-        if not os.environ.get("DISPLAY"):
-            from zabbix_cli.output.console import print_path
-
+        if not os.environ.get("DISPLAY") and not force:
             print_path(directory)
-            if not force:
-                return
+            return
         subprocess.run([command or "xdg-open", spath])
+    success(f"Opened {directory}")
 
 
 def mkdir_if_not_exists(path: Path) -> None:


### PR DESCRIPTION
Moves printing to the `open_directory` function. I would have preferred it to not be in control of printing, but the alternative is refactoring it to either returning a result type or raising exception when no display is supported. Both are overkill since we likely will never call the function outside of `open`.