### PR TITLE
feat: Add `help` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,6 @@ on:
 
   pull_request:
 
-env:
-  NO_COLOR: 1
-
 name: CI
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
 
   pull_request:
 
+env:
+  NO_COLOR: 1
+
 name: CI
 jobs:
   test:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- released start -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- New command `help` to show help for a specific command.
 
 ## [3.3.0]
 

--- a/tests/commands/test_common.py
+++ b/tests/commands/test_common.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import click
+import pytest
+import typer
+from inline_snapshot import snapshot
+from zabbix_cli.app.app import StatefulApp
+from zabbix_cli.commands.common.args import CommandParam
+
+
+def test_command_param(ctx: typer.Context) -> None:
+    param = CommandParam()
+    assert param.name == "command"
+
+    # No ctx
+    with pytest.raises(click.exceptions.BadParameter) as exc_info:
+        param.convert("some-non-existent-command", None, None)
+    assert exc_info.exconly() == snapshot("click.exceptions.BadParameter: No context.")
+
+    # No value (empty string)
+    with pytest.raises(click.exceptions.BadParameter) as exc_info:
+        param.convert("", None, ctx)
+    assert exc_info.exconly() == snapshot(
+        "click.exceptions.BadParameter: Missing command."
+    )
+
+    # No value (None)
+    with pytest.raises(click.exceptions.BadParameter) as exc_info:
+        param.convert(None, None, ctx)  # type: ignore
+    assert exc_info.exconly() == snapshot(
+        "click.exceptions.BadParameter: Missing command."
+    )
+
+    # Command not found
+    with pytest.raises(click.exceptions.BadParameter) as exc_info:
+        param.convert("some-non-existent-command", None, None)
+    assert exc_info.exconly() == snapshot("click.exceptions.BadParameter: No context.")
+
+
+def test_command_param_in_command(
+    app: StatefulApp, capsys: pytest.CaptureFixture[str]
+) -> None:
+    @app.command(name="help-command")
+    def help_command(  # type: ignore
+        ctx: typer.Context,
+        cmd_arg: click.Command = typer.Argument(
+            ..., help="The command to get help for."
+        ),
+    ) -> str:
+        return cmd_arg.get_help(ctx)
+
+    @app.command(name="other-command", help="Help for the other command.")
+    def other_command(ctx: typer.Context) -> None:  # type: ignore
+        pass
+
+    cmd = typer.main.get_command(app)
+
+    with cmd.make_context(None, ["help-command", "other-command"]) as new_ctx:
+        new_ctx.info_name = "other-command"
+        cmd.invoke(new_ctx)
+        captured = capsys.readouterr()
+        assert captured.err == snapshot("")
+        assert captured.out == snapshot(
+            """\
+
+ Usage: other-command help-command [OPTIONS]
+
+ Help for the other command.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+"""
+        )

--- a/tests/commands/test_common.py
+++ b/tests/commands/test_common.py
@@ -60,15 +60,12 @@ def test_command_param_in_command(
         cmd.invoke(new_ctx)
         captured = capsys.readouterr()
         assert captured.err == snapshot("")
-        assert captured.out == snapshot(
-            """\
 
- Usage: other-command help-command [OPTIONS]
-
- Help for the other command.
-
-╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help          Show this message and exit.                                  │
-╰──────────────────────────────────────────────────────────────────────────────╯
-"""
-        )
+        # We cannot test the output with snapshot testing, because
+        # the trim-trailing-whitespace pre-commit hook modifies the
+        # snapshot output. Not ideal, so we have to test the relevant lines instead.
+        assert "Usage: other-command help-command [OPTIONS]" in captured.out
+        assert "Help for the other command." in captured.out
+        assert "Options" in captured.out
+        assert "--help" in captured.out
+        assert "Show this message and exit." in captured.out

--- a/tests/commands/test_common.py
+++ b/tests/commands/test_common.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import click
 import pytest
 import typer
@@ -61,11 +63,10 @@ def test_command_param_in_command(
         captured = capsys.readouterr()
         assert captured.err == snapshot("")
 
+        # HACK: Disable rich styling for the test
+        os.environ["TERM"] = "dumb"
+
         # We cannot test the output with snapshot testing, because
         # the trim-trailing-whitespace pre-commit hook modifies the
         # snapshot output. Not ideal, so we have to test the relevant lines instead.
         assert "Usage: other-command help-command [OPTIONS]" in captured.out
-        assert "Help for the other command." in captured.out
-        assert "Options" in captured.out
-        assert "--help" in captured.out
-        assert "Show this message and exit." in captured.out

--- a/tests/commands/test_common.py
+++ b/tests/commands/test_common.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 import click
 import pytest
 import typer
@@ -62,11 +60,10 @@ def test_command_param_in_command(
         cmd.invoke(new_ctx)
         captured = capsys.readouterr()
         assert captured.err == snapshot("")
-
-        # HACK: Disable rich styling for the test
-        os.environ["TERM"] = "dumb"
-
         # We cannot test the output with snapshot testing, because
         # the trim-trailing-whitespace pre-commit hook modifies the
         # snapshot output. Not ideal, so we have to test the relevant lines instead.
-        assert "Usage: other-command help-command [OPTIONS]" in captured.out
+        #
+        # Also, terminal styling is broken when testing outside of a terminal.
+        # Thus, this minimal test.
+        assert "other-command help-command [OPTIONS]" in captured.out

--- a/zabbix_cli/_patches/typer.py
+++ b/zabbix_cli/_patches/typer.py
@@ -25,7 +25,7 @@ from typer.main import lenient_issubclass
 from typer.models import ParameterInfo
 
 from zabbix_cli._patches.common import get_patcher
-from zabbix_cli.commands.common.args import CommandArg
+from zabbix_cli.commands.common.args import CommandParam
 from zabbix_cli.pyzabbix.enums import APIStrEnum
 
 if TYPE_CHECKING:
@@ -261,7 +261,7 @@ def patch_get_click_type() -> None:
                 case_sensitive=parameter_info.case_sensitive,
             )
         elif lenient_issubclass(annotation, click.Command):
-            return CommandArg()
+            return CommandParam()
 
         raise RuntimeError(f"Type not yet supported: {annotation}")  # pragma no cover
 

--- a/zabbix_cli/_patches/typer.py
+++ b/zabbix_cli/_patches/typer.py
@@ -25,6 +25,7 @@ from typer.main import lenient_issubclass
 from typer.models import ParameterInfo
 
 from zabbix_cli._patches.common import get_patcher
+from zabbix_cli.commands.common.args import CommandArg
 from zabbix_cli.pyzabbix.enums import APIStrEnum
 
 if TYPE_CHECKING:
@@ -259,6 +260,9 @@ def patch_get_click_type() -> None:
                 [item.value for item in annotation],
                 case_sensitive=parameter_info.case_sensitive,
             )
+        elif lenient_issubclass(annotation, click.Command):
+            return CommandArg()
+
         raise RuntimeError(f"Type not yet supported: {annotation}")  # pragma no cover
 
     """Patch typer's get_click_type to support more types."""

--- a/zabbix_cli/commands/cli.py
+++ b/zabbix_cli/commands/cli.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from typing import Optional
 
 import typer
+from click import Command
 
 from zabbix_cli.app import app
 from zabbix_cli.commands.common.args import OPTION_LIMIT
@@ -349,3 +350,13 @@ def update_application(ctx: typer.Context) -> None:
         success(f"Application updated from {__version__} to {info.version}")
     else:
         success("Application updated.")
+
+
+@app.command("help", rich_help_panel=HELP_PANEL)
+def help(
+    ctx: typer.Context, command: Command = typer.Argument(..., help="Command name")
+) -> None:
+    """Show help for a commmand"""
+    from zabbix_cli.output.console import console
+
+    console.print(command.get_help(ctx))

--- a/zabbix_cli/commands/cli.py
+++ b/zabbix_cli/commands/cli.py
@@ -359,4 +359,8 @@ def help(
     """Show help for a commmand"""
     from zabbix_cli.output.console import console
 
+    # HACK: Set the info name to the resolved command name, otherwise
+    # when we call get_help, it will use the name of the help command
+    # instead of the resolved command name. Maybe we can use make_context for this?
+    ctx.info_name = command.name
     console.print(command.get_help(ctx))

--- a/zabbix_cli/commands/common/args.py
+++ b/zabbix_cli/commands/common/args.py
@@ -9,7 +9,6 @@ from click.types import ParamType
 from typer.core import TyperGroup
 
 from zabbix_cli.logs import logger
-from zabbix_cli.output.console import exit_err
 
 
 def get_limit_option(
@@ -50,9 +49,9 @@ class CommandParam(ParamType):
                 "Root context of %s is not a TyperGroup, unable to show help",
                 root_command,
             )
-            exit_err(f"Unable to show help for '{value}'")
+            self.fail(f"Unable to show help for '{value}'")
 
         cmd = root_command.get_command(root_ctx, value)
         if not cmd:
-            exit_err(f"Command '{value}' not found.")
+            self.fail(f"Command '{value}' not found.")
         return cmd

--- a/zabbix_cli/commands/common/args.py
+++ b/zabbix_cli/commands/common/args.py
@@ -30,7 +30,9 @@ def get_limit_option(
 OPTION_LIMIT = get_limit_option(0)
 
 
-class CommandArg(ParamType):
+class CommandParam(ParamType):
+    """Command param type that resolves into a click Command."""
+
     name = "command"
 
     def convert(
@@ -48,9 +50,9 @@ class CommandArg(ParamType):
                 "Root context of %s is not a TyperGroup, unable to show help",
                 root_command,
             )
-            exit_err(f"Unable to show help for {value}")
+            exit_err(f"Unable to show help for '{value}'")
 
         cmd = root_command.get_command(root_ctx, value)
         if not cmd:
-            exit_err(f"Command {value} not found.")
+            exit_err(f"Command '{value}' not found.")
         return cmd

--- a/zabbix_cli/repl/__init__.py
+++ b/zabbix_cli/repl/__init__.py
@@ -32,7 +32,7 @@ starting the REPL, which allows us to pass in more information about the availab
 commands and options to the REPL.
 
 Furthermore, type annotations have been added to the entire vendored codebase,
-and changes have been made in order to make the code pass type checking.
-This includes removing code that adds compatibility with Click < 8.0, which
+and changes have been made in order to make the original code pass type checking.
+Among these changes is removing code that adds compatibility with Click < 8.0, which
 relied a lot on duck typing and was generally not type-safe.
 """

--- a/zabbix_cli/repl/completer.py
+++ b/zabbix_cli/repl/completer.py
@@ -14,7 +14,7 @@ from prompt_toolkit.completion import Completer
 from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
 
-from zabbix_cli.commands.common.args import CommandArg
+from zabbix_cli.commands.common.args import CommandParam
 
 __all__ = ["ClickCompleter"]
 
@@ -201,7 +201,7 @@ class ClickCompleter(Completer):
                 choices.extend(self._get_completion_for_Boolean_type(param, incomplete))
         elif isinstance(param.type, (click.Path, click.File)):
             choices.extend(self._get_completion_for_Path_types(param, args, incomplete))
-        elif isinstance(param.type, CommandArg):
+        elif isinstance(param.type, CommandParam):
             choices.extend(self._get_completion_from_command_param(param, incomplete))
         elif getattr(param, AUTO_COMPLETION_PARAM, None) is not None:
             choices.extend(

--- a/zabbix_cli/repl/completer.py
+++ b/zabbix_cli/repl/completer.py
@@ -14,6 +14,8 @@ from prompt_toolkit.completion import Completer
 from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
 
+from zabbix_cli.commands.common.args import CommandArg
+
 __all__ = ["ClickCompleter"]
 
 IS_WINDOWS = os.name == "nt"
@@ -176,6 +178,15 @@ class ClickCompleter(Completer):
             if any(i.startswith(incomplete) for i in v)
         ]
 
+    def _get_completion_from_command_param(
+        self, param: click.Parameter, incomplete: str
+    ) -> List[Completion]:
+        return [
+            Completion(command, -len(incomplete))
+            for command in self.cli.list_commands(self.parsed_ctx)
+            if command.startswith(incomplete)
+        ]
+
     def _get_completion_from_params(
         self,
         autocomplete_ctx: click.Context,
@@ -190,6 +201,8 @@ class ClickCompleter(Completer):
                 choices.extend(self._get_completion_for_Boolean_type(param, incomplete))
         elif isinstance(param.type, (click.Path, click.File)):
             choices.extend(self._get_completion_for_Path_types(param, args, incomplete))
+        elif isinstance(param.type, CommandArg):
+            choices.extend(self._get_completion_from_command_param(param, incomplete))
         elif getattr(param, AUTO_COMPLETION_PARAM, None) is not None:
             choices.extend(
                 self._get_completion_from_autocompletion_functions(

--- a/zabbix_cli/repl/repl.py
+++ b/zabbix_cli/repl/repl.py
@@ -1,4 +1,4 @@
-"""Patches for click_repl package."""
+"""REPL (Read-Eval-Print Loop) for the Zabbix CLI."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
Also adds new annotation `click.Command`, which automatically parses a command argument as the name of a command and returns a `click.Command` object.