### PR TITLE
Deprecate `login` command

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Deprecated
 
-- `login` command is now hidden. It is fundamentally flawed and will likely be removed in a future release.
-  - Restart the application to log in with a different method instead.
+- `login` command. It is fundamentally flawed and is slated to be removed in a future version unless a valid use case is presented.
+  - Restart the application with a different configuration or launch options to change login methods instead.
 
 ### Fixed
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `login` command is now hidden. It is fundamentally flawed and will likely be removed in a future release.
+  - Restart the application to log in with a different method instead.
+
 ### Fixed
 
 - Ordering of User commands in the help output.

--- a/tests/pyzabbix/test_client.py
+++ b/tests/pyzabbix/test_client.py
@@ -4,6 +4,11 @@ from typing import Any
 from typing import Dict
 
 import pytest
+from inline_snapshot import snapshot
+from packaging.version import Version
+from zabbix_cli.exceptions import ZabbixAPILoginError
+from zabbix_cli.exceptions import ZabbixAPILogoutError
+from zabbix_cli.pyzabbix.client import ZabbixAPI
 from zabbix_cli.pyzabbix.client import add_param
 from zabbix_cli.pyzabbix.client import append_param
 
@@ -70,3 +75,41 @@ def test_add_param(inp: Any, subkey: str, value: Any, expect: Dict[str, Any]) ->
     result = add_param(inp, "search", subkey, value)
     assert result == expect
     # Check in-place modification
+
+
+def test_login_fails(zabbix_client: ZabbixAPI, monkeypatch: pytest.MonkeyPatch) -> None:
+    zabbix_client.set_url("http://some-url-that-will-fail.gg")
+    assert zabbix_client.url == snapshot(
+        "http://some-url-that-will-fail.gg/api_jsonrpc.php"
+    )
+
+    # Patch the version check
+    monkeypatch.setattr(zabbix_client, "api_version", lambda: Version("7.0.0"))
+
+    with pytest.raises(ZabbixAPILoginError) as exc_info:
+        zabbix_client.login(user="username", password="password")
+
+    assert exc_info.exconly() == snapshot(
+        "zabbix_cli.exceptions.ZabbixAPILoginError: Failed to log in to Zabbix: Failed to send request to http://some-url-that-will-fail.gg/api_jsonrpc.php (user.login) with params {'username': 'username', 'password': 'password'}"
+    )
+    assert str(exc_info.value) == snapshot(
+        "Failed to log in to Zabbix: Failed to send request to http://some-url-that-will-fail.gg/api_jsonrpc.php (user.login) with params {'username': 'username', 'password': 'password'}"
+    )
+
+
+def test_logout_fails(zabbix_client: ZabbixAPI) -> None:
+    """Test that we get the correct exception type when login fails
+    due to a connection error."""
+    zabbix_client.set_url("http://some-url-that-will-fail.gg")
+    assert zabbix_client.url == snapshot(
+        "http://some-url-that-will-fail.gg/api_jsonrpc.php"
+    )
+
+    zabbix_client.auth = "authtoken123456789"
+
+    with pytest.raises(ZabbixAPILogoutError) as exc_info:
+        zabbix_client.logout()
+
+    assert exc_info.exconly() == snapshot(
+        "zabbix_cli.exceptions.ZabbixAPILogoutError: Failed to log out of Zabbix: Failed to send request to http://some-url-that-will-fail.gg/api_jsonrpc.php (user.logout) with params {}"
+    )

--- a/zabbix_cli/auth.py
+++ b/zabbix_cli/auth.py
@@ -38,7 +38,6 @@ from zabbix_cli.exceptions import ZabbixAPIException
 from zabbix_cli.logs import add_user
 from zabbix_cli.output.console import err_console
 from zabbix_cli.output.console import error
-from zabbix_cli.output.console import exit_err
 from zabbix_cli.output.console import warning
 from zabbix_cli.output.prompts import str_prompt
 from zabbix_cli.pyzabbix.client import ZabbixAPI
@@ -358,14 +357,9 @@ def login(config: Config) -> ZabbixAPI:
 
 def logout(client: ZabbixAPI, config: Config) -> None:
     """Log out of the current Zabbix API session."""
-    try:
-        client.logout()
-        if config.app.use_auth_token_file:
-            clear_auth_token_file(config)
-    except ZabbixAPIException as e:
-        exit_err(f"Failed to log out of Zabbix API session: {e}")
-    except AuthTokenFileError as e:
-        exit_err(str(e))
+    client.logout()
+    if config.app.use_auth_token_file:
+        clear_auth_token_file(config)
 
 
 def prompt_username_password(username: str) -> Tuple[str, str]:
@@ -443,7 +437,6 @@ def clear_auth_token_file(config: Optional[Config] = None) -> None:
     """Clear the contents of the auth token file.
 
     Attempts to clear both the new and the old auth token file locations.
-    Optionally also clears the loaded auth token from the config object.
     """
     for file in get_auth_token_file_paths(config):
         if not file.exists():

--- a/zabbix_cli/exceptions.py
+++ b/zabbix_cli/exceptions.py
@@ -132,7 +132,7 @@ class ZabbixAPIRequestError(ZabbixAPIException):
         return reason
 
 
-class ZabbixAPITokenExpiredError(ZabbixAPIRequestError):
+class ZabbixAPITokenExpiredError(ZabbixAPIRequestError, AuthError):
     """Zabbix API token expired error."""
 
 
@@ -152,6 +152,14 @@ class ZabbixAPICallError(ZabbixAPIException):
         if self.__cause__ and isinstance(self.__cause__, ZabbixAPIRequestError):
             msg = f"{msg}: {self.__cause__.reason()}"
         return msg
+
+
+class ZabbixAPILoginError(ZabbixAPICallError, AuthError):
+    """Zabbix API login error."""
+
+
+class ZabbixAPILogoutError(ZabbixAPICallError, AuthError):
+    """Zabbix API logout error."""
 
 
 class ZabbixNotFoundError(ZabbixAPICallError):

--- a/zabbix_cli/pyzabbix/client.py
+++ b/zabbix_cli/pyzabbix/client.py
@@ -37,6 +37,8 @@ from zabbix_cli.__about__ import __version__
 from zabbix_cli.cache import ZabbixCache
 from zabbix_cli.exceptions import ZabbixAPICallError
 from zabbix_cli.exceptions import ZabbixAPIException
+from zabbix_cli.exceptions import ZabbixAPILoginError
+from zabbix_cli.exceptions import ZabbixAPILogoutError
 from zabbix_cli.exceptions import ZabbixAPINotAuthorizedError
 from zabbix_cli.exceptions import ZabbixAPIRequestError
 from zabbix_cli.exceptions import ZabbixAPIResponseParsingError
@@ -334,12 +336,10 @@ class ZabbixAPI:
             try:
                 auth = self.user.login(**params)
             except ZabbixAPIRequestError as e:
-                raise ZabbixAPIRequestError(
-                    f"Failed to log in to Zabbix API: {e.reason()}"
-                ) from e
+                raise ZabbixAPILoginError("Failed to log in to Zabbix") from e
             except Exception as e:
-                raise ZabbixAPIRequestError(
-                    f"Failed to log in to Zabbix API: {e}"
+                raise ZabbixAPILoginError(
+                    "Unknown error when trying to log in to Zabbix"
                 ) from e
             else:
                 self.auth = str(auth) if auth else ""
@@ -370,7 +370,7 @@ class ZabbixAPI:
                 "Attempted to log out of Zabbix API with expired token: %s", self.auth
             )
         except ZabbixAPIRequestError as e:
-            raise ZabbixAPICallError("Failed to log out of Zabbix API: %s", e) from e
+            raise ZabbixAPILogoutError("Failed to log out of Zabbix") from e
         self.auth = ""
 
     def confimport(self, format: ExportFormat, source: str, rules: ImportRules) -> Any:

--- a/zabbix_cli/state.py
+++ b/zabbix_cli/state.py
@@ -245,7 +245,13 @@ class State:
             or self.client.use_api_token
         ):
             return
-        self.logout()
+        try:
+            self.logout()
+        except Exception as e:
+            from zabbix_cli.exceptions import handle_exception
+
+            # Outside of main loop, handle the exception
+            handle_exception(e)
 
 
 def get_state() -> State:


### PR DESCRIPTION
This PR deprecates the `login` command, and refactors exception handling within login/logout commands to be more consistent with the overall application design. Login/logout now raises proper exceptions instead of calling `exit_err`, so that we can catch and handle these exceptions where it is required.