### PR TITLE
feat: Show media type `type` human-readable string in table

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `create_notification_user`: Now adds users to the default user group in addition to the notification user group to match behavior in V2.
+- `show_media_types`: Now shows the formatted string representation of the media type `type` field instead of an integer.
 
 ### Deprecated
 

--- a/zabbix_cli/pyzabbix/enums.py
+++ b/zabbix_cli/pyzabbix/enums.py
@@ -112,7 +112,7 @@ class Choice(Enum):
     def from_prompt(
         cls: Type[MixinType],
         prompt: Optional[str] = None,
-        default: MixinType = ...,
+        default: Any = ...,
     ) -> MixinType:
         """Prompt the user to select a choice from the enum.
 
@@ -398,6 +398,16 @@ class MaintenanceWeekType(APIStrEnum):
     THIRD_WEEK = APIStr("third week", 3)
     FOURTH_WEEK = APIStr("fourth week", 4)
     LAST_WEEK = APIStr("last week", 5)
+
+
+class MediaTypeType(APIStrEnum):
+    """Type of media type."""
+
+    EMAIL = APIStr("email", 0)
+    SCRIPT = APIStr("script", 1)
+    SMS = APIStr("SMS", 2)
+    WEBHOOK = APIStr("webhook", 4)
+    # no 3 value in API
 
 
 class MonitoredBy(APIStrEnum):  # >=7.0 only

--- a/zabbix_cli/pyzabbix/types.py
+++ b/zabbix_cli/pyzabbix/types.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from datetime import timedelta
-from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import Iterable
@@ -46,6 +45,8 @@ from typing_extensions import Literal
 from typing_extensions import TypeAliasType
 from typing_extensions import TypedDict
 
+from zabbix_cli.models import ColsRowsType
+from zabbix_cli.models import RowsType
 from zabbix_cli.models import TableRenderable
 from zabbix_cli.output.style import Color
 from zabbix_cli.pyzabbix.enums import AckStatus
@@ -61,6 +62,7 @@ from zabbix_cli.pyzabbix.enums import MacroType
 from zabbix_cli.pyzabbix.enums import MaintenancePeriodType
 from zabbix_cli.pyzabbix.enums import MaintenanceStatus
 from zabbix_cli.pyzabbix.enums import MaintenanceWeekType
+from zabbix_cli.pyzabbix.enums import MediaTypeType
 from zabbix_cli.pyzabbix.enums import MonitoredBy
 from zabbix_cli.pyzabbix.enums import MonitoringStatus
 from zabbix_cli.pyzabbix.enums import ProxyCompatibility
@@ -76,11 +78,6 @@ from zabbix_cli.utils.utils import get_maintenance_active_days
 from zabbix_cli.utils.utils import get_maintenance_active_months
 from zabbix_cli.utils.utils import get_maintenance_status
 from zabbix_cli.utils.utils import get_monitoring_status
-
-if TYPE_CHECKING:
-    from zabbix_cli.models import ColsRowsType
-    from zabbix_cli.models import RowsType
-
 
 logger = logging.getLogger(__name__)
 
@@ -842,6 +839,23 @@ class MediaType(ZabbixAPIBaseModel):
     name: str
     type: int
     description: Optional[str] = None
+
+    @computed_field
+    @property
+    def type_str(self) -> str:
+        return MediaTypeType.string_from_value(self.type)
+
+    def __cols_rows__(self) -> ColsRowsType:
+        cols = ["ID", "Name", "Type", "Description"]
+        rows: RowsType = [
+            [
+                self.mediatypeid,
+                self.name,
+                self.type_str,
+                self.description or "",
+            ]
+        ]
+        return cols, rows
 
 
 class UserMedia(ZabbixAPIBaseModel):


### PR DESCRIPTION
Show a string for the `type` field in `show_media_types` instead of its integer value (which is meaningless for users).