### PR TITLE
refactor: `ZabbixAPI` exception handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `create_notification_user`: Now adds users to the default user group in addition to the notification user group to match behavior in V2.
 - `show_media_types`: Now shows the formatted string representation of the media type `type` field instead of an integer.
+- Auth tokens and passwords from API request errors are now masked by default in output.
 
 ### Deprecated
 

--- a/zabbix_cli/exceptions.py
+++ b/zabbix_cli/exceptions.py
@@ -144,6 +144,10 @@ class ZabbixAPIResponseParsingError(ZabbixAPIRequestError):
     """Zabbix API request error."""
 
 
+class ZabbixAPISessionExpired(ZabbixAPIRequestError):
+    """Zabbix API session expired."""
+
+
 class ZabbixAPICallError(ZabbixAPIException):
     """Zabbix API request error."""
 


### PR DESCRIPTION
Moves exception handling to separate method, redacts sensitive info, and adds detection for expired sessions.

In a future PR, we can use expired sessions to prompt for re-authentication. Need to write an issue for that.