### PR TITLE
Fix rich prompt type checking errors

### DIFF
--- a/zabbix_cli/output/prompts.py
+++ b/zabbix_cli/output/prompts.py
@@ -89,7 +89,7 @@ def prompt_msg(*msgs: str) -> str:
 @no_headless
 def str_prompt(
     prompt: str,
-    default: str = ...,
+    default: str = ...,  # pyright: ignore[reportArgumentType] # rich uses ... to signify no default
     password: bool = False,
     show_default: bool = True,
     choices: Optional[List[str]] = None,
@@ -123,7 +123,7 @@ def str_prompt(
         by default None
     """
     # Don't permit secrets to be shown ever + no empty defaults shown
-    if password or default is ... or not default:
+    if password or default is ... or not default:  # pyright: ignore[reportUnnecessaryComparison]
         show_default = False
 
     # Notify user that a default secret will be used,
@@ -340,7 +340,7 @@ def _number_prompt(
 @no_headless
 def bool_prompt(
     prompt: str,
-    default: Any = ...,
+    default: bool = ...,  # pyright: ignore[reportArgumentType] # rich uses ... to signify no default
     show_default: bool = True,
     warning: bool = False,
     **kwargs: Any,
@@ -357,7 +357,7 @@ def bool_prompt(
 @no_headless
 def path_prompt(
     prompt: str,
-    default: str | Path = ...,
+    default: str | Path = ...,  # pyright: ignore[reportArgumentType] # rich uses ... to signify no default
     show_default: bool = True,
     exist_ok: bool = True,
     must_exist: bool = False,

--- a/zabbix_cli/pyzabbix/enums.py
+++ b/zabbix_cli/pyzabbix/enums.py
@@ -112,7 +112,7 @@ class Choice(Enum):
     def from_prompt(
         cls: Type[MixinType],
         prompt: Optional[str] = None,
-        default: Any = ...,
+        default: MixinType = ...,  # pyright: ignore[reportArgumentType] # rich Prompt.ask default uses ...
     ) -> MixinType:
         """Prompt the user to select a choice from the enum.
 
@@ -131,7 +131,7 @@ class Choice(Enum):
             # Uppercase first letter without mangling the rest of the string
             if prompt and prompt[0].islower():
                 prompt = prompt[0].upper() + prompt[1:]
-        default = default if default is ... else str(default)
+        default = default if default is ... else str(default)  # pyright: ignore[reportUnnecessaryComparison]
         choice = str_prompt(
             prompt,
             choices=cls.choices(),


### PR DESCRIPTION
Rich prompts have inflexible overloads + type annotations, which means we need to pass in `...` to signify a default value. However, that requires using `Any` as the annotation, which in turn destroys our own type checking of prompt default values. This PR adds `pyright: ignore` comments wherever `...` defaults are used, so that we can maintain the correct type annotations but still use the "correct" default value to signify "no default".