### PR TITLE
feat: Add `ZABBIX_URL`, prioritize env over config.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- released start -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Environment variable `ZABBIX_URL` to specify the URL for the Zabbix API.
+
+### Changed
+
+- Authentication info from environment variables now take priority over the configuration file.
 
 ## [3.4.2](https://github.com/unioslo/zabbix-cli/releases/tag/3.4.2) - 2024-12-16
 

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -2,12 +2,12 @@
 
 Zabbix-cli provides several ways to authenticate. They are tried in the following order:
 
-1. [Token - Config file](#config-file)
 1. [Token - Environment variables](#environment-variables)
+1. [Token - Config file](#config-file)
 1. [Token - Auth token file](#auth-token-file)
+1. [Password - Environment variables](#environment-variables_1)
 1. [Password - Config file](#config-file_1)
 1. [Password - Auth file](#auth-file)
-1. [Password - Environment variables](#environment-variables_1)
 1. [Password - Prompt](#prompt)
 
 ## Token
@@ -17,6 +17,14 @@ The application supports authenticating with an API or session token. API tokens
 !!! info "Session vs API token"
     Semantically, a session token and API token are the same thing from an API authentication perspective. They are both sent as the `auth` parameter in the Zabbix API requests.
 
+### Environment variables
+
+The API token can be set as an environment variable:
+
+```bash
+export ZABBIX_API_TOKEN="API TOKEN"
+```
+
 ### Config file
 
 The token can be set directly in the config file:
@@ -24,14 +32,6 @@ The token can be set directly in the config file:
 ```toml
 [api]
 auth_token = "API_TOKEN"
-```
-
-### Environment variables
-
-The API token can be set as an environment variable:
-
-```bash
-export ZABBIX_API_TOKEN="API TOKEN"
 ```
 
 ### Auth token file
@@ -62,6 +62,15 @@ When `allow_insecure_auth_file` is set to `false`, the application will attempt 
 
 The application supports authenticating with a username and password. The password can be set in the config file, an auth file, as environment variables, or prompted for when starting the application.
 
+### Environment variables
+
+The username and password can be set as environment variables:
+
+```bash
+export ZABBIX_USERNAME="Admin"
+export ZABBIX_PASSWORD="zabbix"
+```
+
 ### Config file
 
 The password can be set directly in the config file:
@@ -87,15 +96,6 @@ The location of the auth file file can be changed in the config file:
 auth_file = "~/.zabbix-cli_auth"
 ```
 
-### Environment variables
-
-The username and password can be set as environment variables:
-
-```bash
-export ZABBIX_USERNAME="Admin"
-export ZABBIX_PASSWORD="zabbix"
-```
-
 ### Prompt
 
 When all other authentication methods fail, the application will prompt for a username and password. The default username in the prompt can be configured:
@@ -104,3 +104,37 @@ When all other authentication methods fail, the application will prompt for a us
 [api]
 username = "Admin"
 ```
+
+## URL
+
+The URL of the Zabbix API can be set in the config file, as an environment variable, or prompted for when starting the application.
+
+They are processed in the following order:
+
+1. [Environment variables](#environment-variables_2)
+1. [Config file](#config-file_2)
+1. [Prompt](#prompt_1)
+
+The URL should not include `/api_jsonrpc.php`.
+
+### Config file
+
+The URL of the Zabbix API can be set in the config file:
+
+```toml
+
+[api]
+url = "http://zabbix.example.com"
+```
+
+### Environment variables
+
+The URL can also be set as an environment variable:
+
+```bash
+export ZABBIX_URL="http://zabbix.example.com"
+```
+
+### Prompt
+
+When all other methods fail, the application will prompt for the URL of the Zabbix API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ test = [
   "pytest-cov>=5.0.0",
   "inline-snapshot>=0.13.0",
   "freezegun>=1.5.1",
+  "pytest-httpserver>=1.1.0",
 ]
 docs = [
   "mkdocs>=1.5.3",

--- a/tests/pyzabbix/test_client.py
+++ b/tests/pyzabbix/test_client.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 from typing import Any
+from typing import Literal
 
 import pytest
 from inline_snapshot import snapshot
+from packaging.version import Version
+from pytest_httpserver import HTTPServer
 from zabbix_cli.exceptions import ZabbixAPILoginError
 from zabbix_cli.exceptions import ZabbixAPILogoutError
 from zabbix_cli.pyzabbix.client import ZabbixAPI
 from zabbix_cli.pyzabbix.client import add_param
 from zabbix_cli.pyzabbix.client import append_param
+
+from tests.conftest import add_httpserver_version_endpoint
 
 
 @pytest.mark.parametrize(
@@ -75,14 +80,13 @@ def test_add_param(inp: Any, subkey: str, value: Any, expect: dict[str, Any]) ->
     # Check in-place modification
 
 
-def test_login_fails(zabbix_client: ZabbixAPI) -> None:
-    zabbix_client.set_url("http://some-url-that-will-fail.gg")
-    assert zabbix_client.url == snapshot(
-        "http://some-url-that-will-fail.gg/api_jsonrpc.php"
-    )
+def test_login_fails(zabbix_client_mock_version: ZabbixAPI) -> None:
+    client = zabbix_client_mock_version
+    client.set_url("http://some-url-that-will-fail.gg")
+    assert client.url == snapshot("http://some-url-that-will-fail.gg/api_jsonrpc.php")
 
     with pytest.raises(ZabbixAPILoginError) as exc_info:
-        zabbix_client.login(user="username", password="password")
+        client.login(user="username", password="password")
 
     assert exc_info.exconly() == snapshot(
         "zabbix_cli.exceptions.ZabbixAPILoginError: Failed to log in to Zabbix: Failed to send request to http://some-url-that-will-fail.gg/api_jsonrpc.php (user.login) with params {'username': 'username', 'password': 'password'}"
@@ -92,19 +96,121 @@ def test_login_fails(zabbix_client: ZabbixAPI) -> None:
     )
 
 
-def test_logout_fails(zabbix_client: ZabbixAPI) -> None:
+def test_logout_fails(zabbix_client_mock_version: ZabbixAPI) -> None:
     """Test that we get the correct exception type when login fails
     due to a connection error."""
-    zabbix_client.set_url("http://some-url-that-will-fail.gg")
-    assert zabbix_client.url == snapshot(
-        "http://some-url-that-will-fail.gg/api_jsonrpc.php"
-    )
+    client = zabbix_client_mock_version
+    client.set_url("http://some-url-that-will-fail.gg")
+    assert client.url == snapshot("http://some-url-that-will-fail.gg/api_jsonrpc.php")
 
-    zabbix_client.auth = "authtoken123456789"
+    client.auth = "authtoken123456789"
 
     with pytest.raises(ZabbixAPILogoutError) as exc_info:
-        zabbix_client.logout()
+        client.logout()
 
     assert exc_info.exconly() == snapshot(
         "zabbix_cli.exceptions.ZabbixAPILogoutError: Failed to log out of Zabbix: Failed to send request to http://some-url-that-will-fail.gg/api_jsonrpc.php (user.logout) with params {}"
     )
+
+
+@pytest.mark.parametrize(
+    "inp, expect",
+    [
+        pytest.param(
+            "http://localhost",
+            "http://localhost/api_jsonrpc.php",
+            id="localhost-no-slash",
+        ),
+        pytest.param(
+            "http://localhost/",
+            "http://localhost/api_jsonrpc.php",
+            id="localhost-with-slash",
+        ),
+        pytest.param(
+            "http://localhost/api_jsonrpc.php",
+            "http://localhost/api_jsonrpc.php",
+            id="localhost-full-url",
+        ),
+        pytest.param(
+            "http://localhost/api_jsonrpc.php/",
+            "http://localhost/api_jsonrpc.php",
+            id="localhost-full-url-with-slash",
+        ),
+        pytest.param(
+            "http://example.com",
+            "http://example.com/api_jsonrpc.php",
+            id="tld-no-slash",
+        ),
+        pytest.param(
+            "http://example.com/",
+            "http://example.com/api_jsonrpc.php",
+            id="tld-with-slash",
+        ),
+        pytest.param(
+            "http://example.com/api_jsonrpc.php",
+            "http://example.com/api_jsonrpc.php",
+            id="tld-full-url",
+        ),
+        pytest.param(
+            "http://example.com/api_jsonrpc.php/",
+            "http://example.com/api_jsonrpc.php",
+            id="tld-full-url-with-slash",
+        ),
+    ],
+)
+def test_client_server_url(inp: str, expect: str) -> None:
+    zabbix_client = ZabbixAPI(server=inp)
+    assert zabbix_client.url == expect
+
+
+AuthMethod = Literal["header", "body"]
+
+
+@pytest.mark.parametrize(
+    "version,expect_method",
+    [
+        pytest.param(Version("5.0.0"), "body", id="5.0.0"),
+        pytest.param(Version("5.2.0"), "body", id="5.2.0"),
+        pytest.param(Version("6.0.0"), "body", id="6.0.0"),
+        pytest.param(Version("6.2.0"), "body", id="6.2.0"),
+        pytest.param(Version("6.4.0"), "header", id="6.4.0"),
+        pytest.param(Version("7.0.0"), "header", id="7.0.0"),
+        pytest.param(Version("7.2.0"), "header", id="7.2.0"),
+    ],
+)
+def test_client_auth_method(
+    zabbix_client: ZabbixAPI,
+    httpserver: HTTPServer,
+    version: Version,
+    expect_method: AuthMethod,
+) -> None:
+    # Add endpoint for version check
+    zabbix_client.set_url(httpserver.url_for("/api_jsonrpc.php"))
+
+    # Set a mock token we can use for testing
+    zabbix_client.auth = "token123"
+
+    # Add endpoint that returns the parametrized version
+    add_httpserver_version_endpoint(httpserver, version, id=0)
+
+    assert zabbix_client.version == version
+
+    data = {"jsonrpc": "2.0", "method": "fake.method", "params": {}, "id": 1}
+    headers = {}
+
+    # We expect auth token to be in header on >= 6.4.0
+    if expect_method == "header":
+        headers["Authorization"] = f"Bearer {zabbix_client.auth}"
+    else:
+        data["auth"] = zabbix_client.auth
+
+    httpserver.expect_oneshot_request(
+        "/api_jsonrpc.php",
+        json=data,
+        headers=headers,
+        method="POST",
+    ).respond_with_json({"jsonrpc": "2.0", "result": "authtoken123456789", "id": 1})
+
+    # Will fail if the auth method is not set correctly
+    resp = zabbix_client.do_request("fake.method")
+    assert resp.result == "authtoken123456789"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import Optional
 
 import pytest
@@ -102,21 +103,8 @@ def _auth_file(tmp_path: Path) -> Path:
     [
         pytest.param(
             [
+                (CredentialsType.AUTH_TOKEN, CredentialsSource.ENV),
                 (CredentialsType.AUTH_TOKEN, CredentialsSource.CONFIG),
-                (CredentialsType.AUTH_TOKEN, CredentialsSource.ENV),
-                (CredentialsType.AUTH_TOKEN, CredentialsSource.FILE),
-                (CredentialsType.PASSWORD, CredentialsSource.CONFIG),
-                (CredentialsType.PASSWORD, CredentialsSource.FILE),
-                (CredentialsType.PASSWORD, CredentialsSource.ENV),
-                (CredentialsType.PASSWORD, CredentialsSource.PROMPT),
-            ],
-            CredentialsType.AUTH_TOKEN,
-            CredentialsSource.CONFIG,
-            id="expect_auth_token_config",
-        ),
-        pytest.param(
-            [
-                (CredentialsType.AUTH_TOKEN, CredentialsSource.ENV),
                 (CredentialsType.AUTH_TOKEN, CredentialsSource.FILE),
                 (CredentialsType.PASSWORD, CredentialsSource.CONFIG),
                 (CredentialsType.PASSWORD, CredentialsSource.FILE),
@@ -126,6 +114,19 @@ def _auth_file(tmp_path: Path) -> Path:
             CredentialsType.AUTH_TOKEN,
             CredentialsSource.ENV,
             id="expect_auth_token_env",
+        ),
+        pytest.param(
+            [
+                (CredentialsType.AUTH_TOKEN, CredentialsSource.CONFIG),
+                (CredentialsType.AUTH_TOKEN, CredentialsSource.FILE),
+                (CredentialsType.PASSWORD, CredentialsSource.CONFIG),
+                (CredentialsType.PASSWORD, CredentialsSource.FILE),
+                (CredentialsType.PASSWORD, CredentialsSource.ENV),
+                (CredentialsType.PASSWORD, CredentialsSource.PROMPT),
+            ],
+            CredentialsType.AUTH_TOKEN,
+            CredentialsSource.CONFIG,
+            id="expect_auth_token_config",
         ),
         pytest.param(
             [
@@ -141,9 +142,19 @@ def _auth_file(tmp_path: Path) -> Path:
         ),
         pytest.param(
             [
+                (CredentialsType.PASSWORD, CredentialsSource.ENV),
                 (CredentialsType.PASSWORD, CredentialsSource.CONFIG),
                 (CredentialsType.PASSWORD, CredentialsSource.FILE),
-                (CredentialsType.PASSWORD, CredentialsSource.ENV),
+                (CredentialsType.PASSWORD, CredentialsSource.PROMPT),
+            ],
+            CredentialsType.PASSWORD,
+            CredentialsSource.ENV,
+            id="expect_password_env",
+        ),
+        pytest.param(
+            [
+                (CredentialsType.PASSWORD, CredentialsSource.CONFIG),
+                (CredentialsType.PASSWORD, CredentialsSource.FILE),
                 (CredentialsType.PASSWORD, CredentialsSource.PROMPT),
             ],
             CredentialsType.PASSWORD,
@@ -153,21 +164,11 @@ def _auth_file(tmp_path: Path) -> Path:
         pytest.param(
             [
                 (CredentialsType.PASSWORD, CredentialsSource.FILE),
-                (CredentialsType.PASSWORD, CredentialsSource.ENV),
                 (CredentialsType.PASSWORD, CredentialsSource.PROMPT),
             ],
             CredentialsType.PASSWORD,
             CredentialsSource.FILE,
             id="expect_password_file",
-        ),
-        pytest.param(
-            [
-                (CredentialsType.PASSWORD, CredentialsSource.ENV),
-                (CredentialsType.PASSWORD, CredentialsSource.PROMPT),
-            ],
-            CredentialsType.PASSWORD,
-            CredentialsSource.ENV,
-            id="expect_password_env",
         ),
         pytest.param(
             [
@@ -201,7 +202,7 @@ def test_authenticator_login_with_any(
     # States reasons for mocking each method
 
     # REASON: Makes HTTP calls to the Zabbix API
-    def mock_login(self: ZabbixAPI, *args, **kwargs):
+    def mock_login(self: ZabbixAPI, *args: Any, **kwargs: Any) -> str:
         self.auth = MOCK_TOKEN
         return self.auth
 
@@ -262,7 +263,7 @@ def test_authenticator_login_with_any(
                 auth_file.write_text(f"{MOCK_USER}::{MOCK_PASSWORD}")
                 config.app.auth_file = auth_file
 
-    client, info = authenticator.login_with_any()
+    _, info = authenticator.login_with_any()
     assert info.credentials.source == expect_source
     assert info.credentials.type == expect_type
     assert info.token == MOCK_TOKEN

--- a/uv.lock
+++ b/uv.lock
@@ -1097,6 +1097,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-httpserver"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/53/aa5aa8518246848251243a21440f167b812bd40896546061c1fda814c10c/pytest_httpserver-1.1.0.tar.gz", hash = "sha256:6b1cb0199e2ed551b1b94d43f096863bbf6ae5bcd7c75c2c06845e5ce2dc8701", size = 67210 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/29/c5dfce47d5f575e46e2d4a4257cd43cc199a8014f506d14d808e03d6f8cd/pytest_httpserver-1.1.0-py3-none-any.whl", hash = "sha256:7ef88be8ed3354b6784daa3daa75a422370327c634053cefb124903fa8d73a41", size = 20671 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1532,8 +1544,20 @@ wheels = [
 ]
 
 [[package]]
+name = "werkzeug"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498 },
+]
+
+[[package]]
 name = "zabbix-cli-uio"
-version = "3.4.1"
+version = "3.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["socks"] },
@@ -1574,6 +1598,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-httpserver" },
     { name = "pyyaml" },
     { name = "ruff" },
     { name = "sanitize-filename" },
@@ -1604,6 +1629,7 @@ test = [
     { name = "inline-snapshot" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-httpserver" },
 ]
 
 [package.metadata]
@@ -1645,6 +1671,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-httpserver", specifier = ">=1.1.0" },
     { name = "pyyaml" },
     { name = "ruff" },
     { name = "sanitize-filename" },
@@ -1676,6 +1703,7 @@ test = [
     { name = "inline-snapshot", specifier = ">=0.13.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-httpserver", specifier = ">=1.1.0" },
 ]
 
 [[package]]

--- a/zabbix_cli/config/constants.py
+++ b/zabbix_cli/config/constants.py
@@ -36,9 +36,10 @@ AUTH_FILE = DATA_DIR / ".zabbix-cli_auth"
 
 # Environment variable names
 class ConfigEnvVars:
-    USERNAME = "ZABBIX_USERNAME"
-    PASSWORD = "ZABBIX_PASSWORD"
     API_TOKEN = "ZABBIX_API_TOKEN"
+    PASSWORD = "ZABBIX_PASSWORD"
+    URL = "ZABBIX_URL"
+    USERNAME = "ZABBIX_USERNAME"
 
 
 class OutputFormat(StrEnum):

--- a/zabbix_cli/utils/fs.py
+++ b/zabbix_cli/utils/fs.py
@@ -92,7 +92,6 @@ def sanitize_filename(filename: str) -> str:
     return re.sub(r"[^\w\-.]", "_", filename)
 
 
-# NOTE: Move to zabbix_cli.utils.fs?
 def make_executable(path: Path) -> None:
     """Make a file executable."""
     if sys.platform == "win32":


### PR DESCRIPTION
Adds new env var `ZABBIX_URL` for specifying a Zabbix URL. Also changes the priority of authentication method sources. 

Now uses the following priority:

- Env
- Config
- Auth (token) file

This ensures one can always override static configuration in config or auth token file with environment variables. All token sources are still prioritized over username/password sources.