### PR TITLE
Fix: Specifying multiple names or IDs causing only last value to be selected

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- released start -->
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- `create_maintenance_definition` with multiple host groups only including the first group in the maintenance definition.
+- Commands that allow multiple names or IDs to be specified should now correctly handle searching for multiple values.
 
 ## [3.5.0](https://github.com/unioslo/zabbix-cli/releases/tag/3.5.0) - 2025-01-13
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `create_maintenance_definition` with multiple host groups only including the first group in the maintenance definition.
+- `create_maintenance_definition` with multiple host groups only including the first group in the maintenance definition for Zabbix >=6.0.
+- `add_user_to_usergroup` and `remove_user_from_usergroup` using deprecated API parameters for Zabbix >=6.0.
 - Commands that allow multiple names or IDs to be specified should now correctly handle searching for multiple values.
 
 ## [3.5.0](https://github.com/unioslo/zabbix-cli/releases/tag/3.5.0) - 2025-01-13

--- a/zabbix_cli/commands/usergroup.py
+++ b/zabbix_cli/commands/usergroup.py
@@ -87,7 +87,7 @@ def add_user_to_usergroup(
 ) -> None:
     """Add users to usergroups.
 
-    Ignores users not in user groups. Users and groups must exist.
+    Users and groups must exist.
     """
     from zabbix_cli.commands.results.usergroup import UsergroupAddUsers
 

--- a/zabbix_cli/pyzabbix/client.py
+++ b/zabbix_cli/pyzabbix/client.py
@@ -1281,10 +1281,10 @@ class ZabbixAPI:
             new_userids = list(set(current_userids + ids_update))
 
         if self.version.release >= (6, 0, 0):
-            params["users"] = {"userid": uid for uid in new_userids}
+            params["users"] = [{"userid": uid} for uid in new_userids]
         else:
             params["userids"] = new_userids
-        self.usergroup.update(usrgrpid=usergroup.usrgrpid, userids=new_userids)
+        self.usergroup.update(**params)
 
     def update_usergroup_rights(
         self,

--- a/zabbix_cli/pyzabbix/client.py
+++ b/zabbix_cli/pyzabbix/client.py
@@ -169,6 +169,14 @@ def parse_name_or_id_arg(
     if "*" in names_or_ids:
         names_or_ids = tuple()
 
+    if len(names_or_ids) > 1:
+        logger.debug(
+            "Multiple names or IDs provided, using search instead of filter for %s",
+            names_or_ids,
+            stacklevel=2,
+        )
+        search = True
+
     if names_or_ids:
         for name_or_id in names_or_ids:
             name_or_id = name_or_id.strip()
@@ -2224,7 +2232,7 @@ class ZabbixAPI:
                 params["hostids"] = [h.hostid for h in hosts]
         if hostgroups:
             if self.version.release >= (6, 0, 0):
-                params["groups"] = {"groupid": hg.groupid for hg in hostgroups}
+                params["groups"] = [{"groupid": hg.groupid} for hg in hostgroups]
             else:
                 params["groupids"] = [hg.groupid for hg in hostgroups]
         if data_collection:


### PR DESCRIPTION
Fixes several commands that allow for multiple names or ids to be specified. A bug caused the `parse_name_or_id_arg` function to overwrite the `filter` value with the last value in the list of usernames or ids when `search=False`. Now, we automatically assume we are searching when given multiple values, as one cannot filter by multiple names.

It is unclear exactly which commands this affected, but in any case, this PR should now make any commands that use the `parse_name_or_id_arg` to behave consistently and in the way we expect.

Furthermore, some bugs related to building params for certain commands in Zabbix >= 6.0 was discovered and fixed (see changelog).