### PR TITLE
ci: Run pyupgrade with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,6 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
-    hooks:
-      - id: pyupgrade
-        args: [--py39-plus, --keep-runtime-typing]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.7.0"
     hooks:

--- a/docs/scripts/utils/commands.py
+++ b/docs/scripts/utils/commands.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from functools import lru_cache
+from functools import cache
 from typing import Any
 from typing import Optional
 from typing import Union
@@ -276,7 +276,7 @@ def get_command_help(command: typer.models.CommandInfo) -> str:
     return ""
 
 
-@lru_cache(maxsize=None)
+@cache
 def get_app_commands(app: typer.Typer) -> list[CommandSummary]:
     """Get a list of commands from a typer app."""
     return _get_app_commands(app)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ extend-select = [
   "TID252",  # flake8-tidy-imports (prefer absolute imports)
   "C4",      # flake8-comprehensions
   "B",       # flake8-bugbear
+  "UP",      # pyupgrade
 ]
 ignore = [
   "E501", # Avoid enforcing line-length violations
@@ -182,3 +183,7 @@ ignore = [
 force-single-line = true
 # Add annotations import to every file
 required-imports = ["from __future__ import annotations"]
+
+[tool.ruff.lint.pyupgrade]
+# Preserve types, even if a file imports `from __future__ import annotations`.
+keep-runtime-typing = true

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from inline_snapshot import snapshot
+from zabbix_cli.repl.repl import _help_internal  # pyright: ignore[reportPrivateUsage]
+
+
+def test_help_internal() -> None:
+    assert _help_internal() == snapshot(
+        """\
+REPL help:
+
+  External Commands:
+    prefix external commands with "!"
+
+  Internal Commands:
+    prefix internal commands with ":"
+    :exit, :q, :quit  exits the repl
+    :?, :h, :help     displays general help information
+"""
+    )

--- a/zabbix_cli/output/prompts.py
+++ b/zabbix_cli/output/prompts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import math
 import os
-from functools import lru_cache
+from functools import cache
 from functools import wraps
 from pathlib import Path
 from typing import Any
@@ -66,7 +66,7 @@ TRUE_ARGS = ["1", "true"]  # case-insensitive
 
 
 # NOTE: if testing this function, clear cache after each test
-@lru_cache(maxsize=None)
+@cache
 def is_headless() -> bool:
     """Determines if we are running in a headless environment (e.g. CI, Docker, etc.)"""
     # Truthy values indicate headless

--- a/zabbix_cli/repl/repl.py
+++ b/zabbix_cli/repl/repl.py
@@ -10,7 +10,6 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import DefaultDict
 from typing import NamedTuple
 from typing import NoReturn
 from typing import Optional
@@ -83,7 +82,7 @@ def _help_internal() -> str:
         formatter.write_text('prefix external commands with "!"')
     with formatter.section("Internal Commands"):
         formatter.write_text('prefix internal commands with ":"')
-        info_table: DefaultDict[str, list[str]] = defaultdict(list)
+        info_table: defaultdict[str, list[str]] = defaultdict(list)
         for mnemonic, target_info in _internal_commands.items():
             info_table[target_info[1]].append(mnemonic)
         formatter.write_dl(


### PR DESCRIPTION
This PR replaces the pyupgade pre-commit hook with the UP ruff rule. 

One of the fixes suggested by UP was to replace `typing.DefaultDict` with `collections.defaultdict` for an annotation in `repl._help_internal()`. I want to ensure that works across all versions, so a test for that function has also been added.