### PR TITLE
feat: Add custom CA file support for `verify_ssl`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for custom CA file bundles for Zabbix API connections. The config option `api.verify_ssl` now accepts a path to a custom CA file bundle.
+
 ### Fixed
 
 - `create_maintenance_definition` with multiple host groups only including the first group in the maintenance definition for Zabbix >=6.0.

--- a/zabbix_cli/config/model.py
+++ b/zabbix_cli/config/model.py
@@ -128,11 +128,11 @@ class APIConfig(BaseModel):
         description="API auth token.",
         examples=["API_TOKEN_123"],
     )
-    verify_ssl: bool = Field(
+    verify_ssl: Union[bool, Path] = Field(
         default=True,
         # Changed in V3: cert_verify -> verify_ssl
         validation_alias=AliasChoices("verify_ssl", "cert_verify"),
-        description="Verify SSL certificate of the Zabbix API host.",
+        description="Verify SSL certificate of the Zabbix API host. Can also be a path to a CA bundle.",
     )
     timeout: Optional[int] = Field(
         default=0,


### PR DESCRIPTION
This PR adds the ability to pass in the path to a custom CA bundle file as the argument to `api.verify_ssl`. 

Also fixes the rendering of union and bool types in the config docs.