### PR TITLE
feat: Command configuration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `create_notification_user --dryrun` option to preview changes without making them.
+- `create_host --create-interface/--no-create-interface` option to control creation of interface when creating a host.
+- Persistent configuration of commands via a new config table `[app.commands]`.
+- Configuration table `app.commands.create_host` to configure the `create_host` command.
+- Configuration option `app.commands.create_host.create_interface` to enable/disable creating interfaces when creating a host.
 
 ### Changed
 

--- a/docs/scripts/gen_config_data.py
+++ b/docs/scripts/gen_config_data.py
@@ -301,6 +301,9 @@ def get_config_options(
             continue
         if not field.annotation:
             continue
+        if field.default is None:
+            continue
+
         if lenient_issubclass(field.annotation, RootModel):
             logging.debug("Skipping %s. It is a root model.", field_name)
             continue
@@ -334,7 +337,7 @@ def generate_config_info() -> ConfigTable:
 
 def main() -> None:
     conf = generate_config_info()
-    out = yaml.dump(conf.model_dump(mode="json"), sort_keys=False)
+    out = yaml.dump(conf.model_dump(mode="json", exclude_none=True), sort_keys=False)
     out = add_path_placeholders(out)  # type: ignore
     # Replace paths with placeholders
     with open(DATA_DIR / "config_options.yaml", "w") as f:

--- a/tests/data/zabbix-cli.toml
+++ b/tests/data/zabbix-cli.toml
@@ -13,16 +13,22 @@ default_notification_users_usergroups = ["All-notification-users"]
 export_directory = "/path/to/exports"
 export_format = "json"
 export_timestamps = false
-use_colors = true
 use_session_file = true
 auth_token_file = "/path/to/auth_token_file"
 auth_file = "/path/to/auth_file"
-use_paging = false
-output_format = "table"
 history = true
 history_file = "/path/to/history_file"
 allow_insecure_auth_file = true
 legacy_json_format = false
+
+[app.commands.create_host]
+create_interface = true
+
+[app.output]
+format = "table"
+color = true
+paging = false
+
 
 [logging]
 enabled = true

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version < '3.13'",
@@ -200,7 +201,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -596,7 +597,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "jinja2" },
@@ -1556,7 +1557,6 @@ wheels = [
 
 [[package]]
 name = "zabbix-cli-uio"
-version = "3.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["socks"] },

--- a/zabbix_cli/config/base.py
+++ b/zabbix_cli/config/base.py
@@ -1,0 +1,42 @@
+"""Base model for all configuration models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ConfigDict
+from pydantic import PrivateAttr
+from pydantic import ValidationInfo
+from pydantic import field_validator
+from pydantic import model_validator
+from typing_extensions import Self
+
+from zabbix_cli.config.utils import check_deprecated_fields
+
+
+class BaseModel(PydanticBaseModel):
+    model_config = ConfigDict(validate_assignment=True, extra="ignore")
+
+    _deprecation_checked: bool = PrivateAttr(default=False)
+    """Has performed a deprecaction check for the fields on the model."""
+
+    @field_validator("*")
+    @classmethod
+    def _conf_bool_validator_compat(cls, v: Any, info: ValidationInfo) -> Any:
+        """Handles old config files that specified bools as ON/OFF."""
+        if not isinstance(v, str):
+            return v
+        if v.upper() == "ON":
+            return True
+        if v.upper() == "OFF":
+            return False
+        return v
+
+    @model_validator(mode="after")
+    def _check_deprecated_fields(self) -> Self:
+        """Check for deprecated fields and log warnings."""
+        if not self._deprecation_checked:
+            check_deprecated_fields(self)
+            self._deprecation_checked = True
+        return self

--- a/zabbix_cli/config/commands.py
+++ b/zabbix_cli/config/commands.py
@@ -1,0 +1,11 @@
+"""Configuration classes for Zabbix CLI commands."""
+
+from __future__ import annotations
+
+from zabbix_cli.config.base import BaseModel
+
+
+class CreateHost(BaseModel):
+    """Configuration for the `create_host` command."""
+
+    create_interface: bool = True

--- a/zabbix_cli/utils/args.py
+++ b/zabbix_cli/utils/args.py
@@ -8,6 +8,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Optional
+from typing import TypeVar
 
 import typer
 
@@ -21,6 +22,8 @@ if TYPE_CHECKING:
     from zabbix_cli.pyzabbix.types import HostGroup
     from zabbix_cli.pyzabbix.types import Template
     from zabbix_cli.pyzabbix.types import TemplateGroup
+
+T = TypeVar("T")
 
 
 def is_set(ctx: typer.Context, option: str) -> bool:
@@ -255,3 +258,24 @@ def check_at_least_one_option_set(ctx: typer.Context) -> None:
     if not any(is_set(ctx, param) for param in optional_params):
         print_help(ctx)
         exit_err("At least one option is required.")
+
+
+def resolve_option(
+    opt: Optional[T], config_opt: Optional[T], *, default: Optional[T] = None
+) -> Optional[T]:
+    """Resolve an option value.
+
+    If the option is not set, return the config value if it is set,
+    otherwise return the default value.
+
+    Args:
+        opt (Optional[T]): The option value.
+        config_opt (Optional[T]): The config value.
+        default (Optional[T], optional): The default value. Defaults to None.
+
+    Returns:
+        Optional[T]: resolved option value.
+    """
+    if opt is None:
+        return config_opt if config_opt is not None else default
+    return opt


### PR DESCRIPTION
This PR adds the ability to persistently configure command option defaults via the config file via a new `[app.commands]` config table. For now, only configuration of `create_host` is implemented.