### PR TITLE
Force-load typer.rich_utils

### DIFF
--- a/zabbix_cli/_patches/typer.py
+++ b/zabbix_cli/_patches/typer.py
@@ -22,6 +22,7 @@ import click
 import typer
 from typer.main import lenient_issubclass
 from typer.models import ParameterInfo
+import typer.rich_utils
 
 from zabbix_cli._patches.common import get_patcher
 from zabbix_cli.commands.common.args import CommandParam


### PR DESCRIPTION
Fixes unioslo/zabbix-cli#311

`typer` started lazy-loading `rich_utils` since 0.17.0, so force-load it here for patching purposes.

From a quick test, this seems to work fine with `typer` 0.13.1 to 0.19.1.