### PR TITLE
Rename usermacro commands, add template macro commands

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **NOTE:** `export_configuration` and `import_configuration` share the same configuration table to maintain consistency.
 - New option `create_user --default-usergroups/--no-default-usergroups`
 - New option `create_notification_user --default-usergroups/--no-default-usergroups`
+- New command `define_template_macro` to define a macro for a template.
+- New command `show_template_macros` to show macros for a template.
 
 ### Changed
 
@@ -37,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `create_notification_user` no longer uses the same default user groups as `create_user`.
   - The default user groups is now set by `app.commands.create_notification_user.usergroups` in the config file.
 - `show_hostgroups` no longer requires a name argument. Shows all host groups by default.
+- Renamed macro commands. The term "usermacro" is a remnant of Zabbix-CLI v2 and only exists as part of the API. In the documentation and web interface, these are simply referred to as "Macros" in the global context and "Host/Template Macros" in the host/template context.
+  - `define_host_usermacro` → `define_host_macro`
+  - `show_host_usermacros` → `show_host_macros`
+  - `show_usermacro_host_list` → `show_macro_hosts`
+  - `show_usermacro_template_list` → `show_macro_templates`
 
 ### Deprecated
 
@@ -48,6 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `app.export_directory`
   - `app.export_format`
   - `app.export_timestamps`
+- Commands containing "usermacro" in the name are deprecated in favor of the new names without "user":
+  - `define_host_usermacro`
+  - `show_host_usermacros`
+  - `show_usermacro_host_list`
+  - `show_usermacro_template_list`
 
 ### Fixed
 

--- a/zabbix_cli/pyzabbix/types.py
+++ b/zabbix_cli/pyzabbix/types.py
@@ -347,6 +347,8 @@ class Template(ZabbixAPIBaseModel):
     templateid: str
     host: str
     hosts: HostList = []
+    macros: list[Macro] = []
+
     templates: list[Template] = []
     """Child templates (templates inherited from this template)."""
 
@@ -359,6 +361,9 @@ class Template(ZabbixAPIBaseModel):
 
     name: Optional[str] = None
     """The visible name of the template."""
+
+    def __str__(self) -> str:
+        return f"{self.name or self.host!r} ({self.templateid})"
 
     def __cols_rows__(self) -> ColsRowsType:
         cols = ["ID", "Name", "Hosts", "Parents", "Children"]


### PR DESCRIPTION
This PR renames all `*_usermacro` commands to `host_macro` and `template_macro` to reflect the naming schemes used in the documentation and web interface. It also adds two new commands to define and show macros for templates.

Overview of current and new names for existing commands as well as new commands.

| Current                        | New                     |
|--------------------------------|-------------------------|
| `define_host_usermacro`        | `define_host_macro`     |
| `show_host_usermacros`         | `show_host_macros`      |
| `show_usermacro_host_list`     | `show_macro_hosts`      |
| `show_usermacro_template_list` | `show_macro_templates`  |
| N/A                            | `define_template_macro` |
| N/A                            | `show_template_macros`  |


---

NOTE: The old command names can still be used, but are hidden and will emit a deprecation warning when used.